### PR TITLE
Refactoring removeWhere to return removedElements

### DIFF
--- a/lib/ordered_set.dart
+++ b/lib/ordered_set.dart
@@ -70,19 +70,21 @@ class OrderedSet<E> extends IterableMixin<E> implements Iterable<E> {
     return true;
   }
 
-  /// Remove all elements that match the [test] condition, returns the amount of element removed.
-  int removeWhere(bool Function(E element) test) {
-    final prevLength = _length;
+  /// Remove all elements that match the [test] condition, returns the removed elements
+  Iterable<E> removeWhere(bool Function(E element) test) {
+    List<E> _removed = [];
     for (final es in _backingSet.toList()) {
-      final removed = es.where(test).length;
-      if (removed == es.length) {
+      final removed = es.where(test);
+      _removed.addAll(removed);
+      _length -= removed.length;
+
+      if (removed.length == es.length) {
         _backingSet.remove(es);
       } else {
         es.removeWhere(test);
       }
-      _length -= removed;
     }
-    return prevLength - _length;
+    return _removed;
   }
 
   /// Remove a single element that is equal to [e].

--- a/test/ordered_set_test.dart
+++ b/test/ordered_set_test.dart
@@ -10,7 +10,7 @@ void main() {
         OrderedSet<int> a = OrderedSet();
         expect(a.addAll([7, 4, 3, 1, 2, 6, 5]), 7);
         expect(a.length, 7);
-        expect(a.removeWhere((e) => e == 3), 1);
+        expect(a.removeWhere((e) => e == 3).length, 1);
         expect(a.length, 6);
         expect(a.toList().join(), '124567');
       });
@@ -18,7 +18,7 @@ void main() {
       test('remove with property', () {
         OrderedSet<int> a = OrderedSet();
         expect(a.addAll([7, 4, 3, 1, 2, 6, 5]), 7);
-        expect(a.removeWhere((e) => e % 2 == 1), 4);
+        expect(a.removeWhere((e) => e % 2 == 1).length, 4);
         expect(a.length, 3);
         expect(a.toList().join(), '246');
       });
@@ -33,7 +33,7 @@ void main() {
         expect(a.add(ComparableObject(1, 'b3')), true);
         expect(a.add(ComparableObject(2, 'a4')), true);
         expect(a.add(ComparableObject(2, 'b4')), true);
-        expect(a.removeWhere((e) => e.name.startsWith('a')), 4);
+        expect(a.removeWhere((e) => e.name.startsWith('a')).length, 4);
         expect(a.length, 4);
         expect(a.toList().join(), 'b1b2b3b4');
       });
@@ -48,7 +48,7 @@ void main() {
         expect(a.add(ComparableObject(1, 'b3')), true);
         expect(a.add(ComparableObject(2, 'a4')), true);
         expect(a.add(ComparableObject(2, 'b4')), true);
-        expect(a.removeWhere((e) => true), 8);
+        expect(a.removeWhere((e) => true).length, 8);
         expect(a.length, 0);
         expect(a.toList().join(), '');
       });

--- a/test/ordered_set_test.dart
+++ b/test/ordered_set_test.dart
@@ -23,6 +23,14 @@ void main() {
         expect(a.toList().join(), '246');
       });
 
+      test('remove returns the removed elements', () {
+        OrderedSet<int> a = OrderedSet();
+        a.addAll([7, 4, 3, 1, 2, 6, 5]);
+        final removed =  a.removeWhere((e) => e <= 2);
+        expect(removed.length, 2);
+        expect(removed.toList().join(), '12');
+      });
+
       test('remove from same group and different groups', () {
         OrderedSet<ComparableObject> a = OrderedSet();
         expect(a.add(ComparableObject(0, 'a1')), true);


### PR DESCRIPTION
## Why

On Flame we do some logic inside the `test` function from the `removeWhere` method. This was causing some weird behaviour, as sometimes the `onDestroy` method of the components were called twice.

After some dig, I discovered that that happened, because `OrderedSet#removeWhere` was calling the test function multiple times eventually.

I did this small refactor to give us an alternative than setting logic inside the test function. As now we get the removed elements instead of the removed length.

This is a breaking change, but I hope this is ok, as there is still ways to the amount of the removed elements, and also a way access than.

If this gets merged, we will be able to replace on Flame, this code:

```dart
    components.removeWhere((c) {
      final destroy = c.destroy();

      if (destroy) {
        c.onDestroy();
      }

      return destroy;
    });
```

By this

```dart
    components
        .removeWhere((c) => c.destroy())
        .forEach((c) => c.onDestroy());
```