### PR TITLE
🏷 Migrate to null-safety

### DIFF
--- a/lib/ordered_set.dart
+++ b/lib/ordered_set.dart
@@ -6,8 +6,8 @@ import 'dart:collection';
 /// Unlike [SplayTreeSet], it allows for several different elements with the same priority to be added.
 /// It also implements [Iterable], so you can iterate it in O(n).
 class OrderedSet<E> extends IterableMixin<E> implements Iterable<E> {
-  SplayTreeSet<List<E>> _backingSet;
-  int _length;
+  late SplayTreeSet<List<E>> _backingSet;
+  late int _length;
 
   // gotten from SplayTreeSet, but those are private there
   static int _dynamicCompare(dynamic a, dynamic b) => Comparable.compare(a, b);
@@ -22,7 +22,7 @@ class OrderedSet<E> extends IterableMixin<E> implements Iterable<E> {
   /// Creates a new [OrderedSet] with the given compare function.
   ///
   /// If the [compare] function is omitted, it defaults to [Comparable.compare], and the elements must be comparable.
-  OrderedSet([int Function(E e1, E e2) compare]) {
+  OrderedSet([int Function(E e1, E e2)? compare]) {
     final comparator = compare ?? _defaultCompare<E>();
     _backingSet = SplayTreeSet<List<E>>((List<E> l1, List<E> l2) {
       if (l1.isEmpty) {
@@ -65,7 +65,7 @@ class OrderedSet<E> extends IterableMixin<E> implements Iterable<E> {
     _length++;
     final added = _backingSet.add([e]);
     if (!added) {
-      _backingSet.lookup([e]).add(e);
+      _backingSet.lookup([e])!.add(e);
     }
     return true;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: ordered_set
 description: A simple implementation of an Ordered Set for Dart that allows multiple items with the same priority.
-version: 2.0.1
+version: 3.0.0-nullsafety.0
 homepage: https://github.com/luanpotter/ordered_set
 
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: '>=2.12.0-29.10.beta <3.0.0'
 
 dev_dependencies:
-  test: ^1.9.4
+  test: ^1.16.0-nullsafety


### PR DESCRIPTION
This prepares for `null-safety` migration after the next major dart sdk release.

As for now, I'd think this could be kept in a separate branch. I'd be happy to retarget the PR to a new branch.