### PR TITLE
Queryable Ordered Set

### DIFF
--- a/lib/queryable_ordered_set.dart
+++ b/lib/queryable_ordered_set.dart
@@ -1,0 +1,64 @@
+import 'ordered_set.dart';
+
+class _CacheEntry<C, T> {
+  final List<C> data;
+
+  _CacheEntry({required this.data});
+
+  bool check(T t) {
+    return t is C;
+  }
+}
+
+class QueryableOrderedSet<T> extends OrderedSet<T> {
+  final Map<Type, _CacheEntry<T, T>> _cache = {};
+
+  QueryableOrderedSet([int Function(T e1, T e2)? compare]) : super(compare);
+
+  void register<C extends T>() {
+    _cache[C] = _CacheEntry<C, T>(
+      data: _filter<C>(),
+    );
+  }
+
+  List<C> query<C extends T>() {
+    final result = _cache[C];
+    if (result == null) {
+      throw 'Cannot query unregistered query $C';
+    }
+    return result.data as List<C>;
+  }
+
+  @override
+  bool add(T t) {
+    if (super.add(t)) {
+      _cache.forEach((key, value) {
+        if (value.check(t)) {
+          value.data.add(t);
+        }
+      });
+      return true;
+    }
+    return false;
+  }
+
+  @override
+  Iterable<T> removeWhere(bool Function(T element) test) {
+    _cache.values.forEach((v) => v.data.removeWhere(test));
+    return super.removeWhere(test);
+  }
+
+  @override
+  bool remove(T e) {
+    _cache.values.forEach((v) => v.data.remove(e));
+    return super.remove(e);
+  }
+
+  @override
+  void clear() {
+    _cache.values.forEach((v) => v.data.clear());
+    super.clear();
+  }
+
+  List<C> _filter<C extends T>() => whereType<C>().toList();
+}

--- a/lib/queryable_ordered_set.dart
+++ b/lib/queryable_ordered_set.dart
@@ -10,17 +10,53 @@ class _CacheEntry<C, T> {
   }
 }
 
+/// This is an implementation of QueryableOrderedSet that allows you to more
+/// efficiently [query] the list.
+///
+/// You can [register] a set of queries, i.e., predefined sub-types, whose
+/// results, i.e., subsets of this set, are then cached. Since the queries
+/// have to be type checks, and types are runtime constants, this can be
+/// vastly optimized.
+///
+/// If you find yourself doing a lot of:
+///
+/// ```dart
+///   orderedSet.whereType<Foo>()
+/// ```
+///
+/// On your code, and are concerned you are iterating a very long O(n) list to
+/// find a handful of elements, specially if this is done every tick, you
+/// can use this class, that pays a small O(number of registers) cost on [add],
+/// but lets you find (specific) subsets at O(0).
 class QueryableOrderedSet<T> extends OrderedSet<T> {
   final Map<Type, _CacheEntry<T, T>> _cache = {};
 
   QueryableOrderedSet([int Function(T e1, T e2)? compare]) : super(compare);
 
+  /// Adds a new cache for a subtype [C] of [T], allowing you to call [query].
+  ///
+  /// If the set is not empty, the current elements will be re-sorted.
+  ///
+  /// It is recommended to [register] all desired types at the beginning of
+  /// your application to avoid recomputing the existing elements upon
+  /// registration.
   void register<C extends T>() {
     _cache[C] = _CacheEntry<C, T>(
       data: _filter<C>(),
     );
   }
 
+  /// Allow you to find a subset of this set with all the elements `e` for
+  /// which the condition `e is C` is true. This is equivalent to
+  ///
+  /// ```dart
+  ///   orderedSet.whereType<C>()
+  /// ```
+  ///
+  /// except that it is O(0).
+  ///
+  /// Note: you *must* call [register] for every type [C] you desire to use
+  /// before calling this.
   List<C> query<C extends T>() {
     final result = _cache[C];
     if (result == null) {

--- a/lib/queryable_ordered_set.dart
+++ b/lib/queryable_ordered_set.dart
@@ -43,12 +43,6 @@ class QueryableOrderedSet<T> extends OrderedSet<T> {
   }
 
   @override
-  Iterable<T> removeWhere(bool Function(T element) test) {
-    _cache.values.forEach((v) => v.data.removeWhere(test));
-    return super.removeWhere(test);
-  }
-
-  @override
   bool remove(T e) {
     _cache.values.forEach((v) => v.data.remove(e));
     return super.remove(e);

--- a/lib/queryable_ordered_set.dart
+++ b/lib/queryable_ordered_set.dart
@@ -10,7 +10,7 @@ class _CacheEntry<C, T> {
   }
 }
 
-/// This is an implementation of QueryableOrderedSet that allows you to more
+/// This is an implementation of [OrderedSet] that allows you to more
 /// efficiently [query] the list.
 ///
 /// You can [register] a set of queries, i.e., predefined sub-types, whose

--- a/test/queryable_ordered_set_test.dart
+++ b/test/queryable_ordered_set_test.dart
@@ -1,0 +1,44 @@
+import 'package:ordered_set/comparing.dart';
+import 'package:ordered_set/queryable_ordered_set.dart';
+import 'package:test/test.dart';
+
+abstract class Animal {
+  String name = '';
+}
+
+abstract class Mammal extends Animal {}
+
+class Bird extends Animal {}
+
+class Fish extends Animal {}
+
+class Dog extends Mammal {}
+
+class Cat extends Mammal {}
+
+class Cod extends Fish {}
+
+void main() {
+  group('QueryableOrderedSet', () {
+    group('#add and #query', () {
+      test('query after registering', () {
+        final dog = Dog()..name = 'Joey';
+        final bird = Bird()..name = 'Louise';
+
+        final orderedSet = QueryableOrderedSet<Animal>(
+          Comparing.on((e) => e.name),
+        );
+        orderedSet.register<Animal>();
+        orderedSet.register<Dog>();
+        orderedSet.register<Bird>();
+
+        orderedSet.add(dog);
+        orderedSet.add(bird);
+
+        expect(orderedSet.query<Animal>(), containsAll(<Animal>[dog, bird]));
+        expect(orderedSet.query<Dog>(), containsAll(<Dog>[dog]));
+        expect(orderedSet.query<Bird>(), containsAll(<Bird>[bird]));
+      });
+    });
+  });
+}


### PR DESCRIPTION
This is one more thing I extracted from Tales (with some improvements). Queryable Ordered Sets allow you to register queries (pre-defined types) that are then cached as sub-lists and can be queried at O(0), at the expense of extra indexing upon add.

This is extremely valuable because on most complex games you need to iterate subsets of the component list every tick, but rarely you add new components.