### PR TITLE
Add `reversed` and `removeAll`

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -63,7 +63,7 @@ jobs:
           channel: 'beta'
       - run: flutter pub get # make sure flutter downloads dart for us
       - run: ./scripts/coverage.sh
-      - uses: coverallsapp/github-action@main
+      - uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
   # END TESTING STAGE

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,7 +3,7 @@ name: cicd
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     types: [opened, reopened, synchronize]
 
@@ -63,7 +63,7 @@ jobs:
           channel: 'beta'
       - run: flutter pub get # make sure flutter downloads dart for us
       - run: ./scripts/coverage.sh
-      - uses: coverallsapp/github-action@master
+      - uses: coverallsapp/github-action@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
   # END TESTING STAGE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Next]
+- Add `OrderedSet.reversed`
+- Add `OrderedSet.removeAll`
+
 ## 4.0.0
 
 - Add `Comparing#mapper`

--- a/lib/comparing.dart
+++ b/lib/comparing.dart
@@ -8,7 +8,7 @@ class Comparing {
     return (a, b) => -comparator(a, b);
   }
 
-  /// Returns a Comparator that compares objects of type T by mapping then to
+  /// Returns a Comparator that compares objects of type T by mapping them to
   /// Comparables.
   static Comparator<T> on<T>(Comparable Function(T t) mapper) {
     return (a, b) => mapper(a).compareTo(mapper(b));

--- a/lib/ordered_set.dart
+++ b/lib/ordered_set.dart
@@ -59,6 +59,7 @@ class OrderedSet<E> extends IterableMixin<E> implements Iterable<E> {
     return _backingSet.expand<E>((es) => es).iterator;
   }
 
+  /// The tree's elements in reversed order, cached when possible.
   Iterable<E> reversed() {
     if (!_validReverseCache) {
       _reverseCache = toList(growable: false).reversed;

--- a/lib/ordered_set.dart
+++ b/lib/ordered_set.dart
@@ -11,7 +11,7 @@ class OrderedSet<E> extends IterableMixin<E> implements Iterable<E> {
   late int _length;
 
   bool _validReverseCache = true;
-  Iterable<E> _reverseCache = Iterable.empty();
+  Iterable<E> _reverseCache = const Iterable.empty();
 
   // Copied from SplayTreeSet, but those are private there
   static int _dynamicCompare(dynamic a, dynamic b) => Comparable.compare(

--- a/lib/ordered_set.dart
+++ b/lib/ordered_set.dart
@@ -86,9 +86,7 @@ class OrderedSet<E> extends IterableMixin<E> implements Iterable<E> {
     final added = _backingSet.add([e]);
     if (!added) {
       _backingSet.lookup([e])!.add(e);
-      // TODO: Shouldn't we return false here and not add the element, to make it a proper set?
     }
-    // TODO: Moved into else if it is decided that duplicate elements are discarded.
     _validReverseCache = false;
     return true;
   }

--- a/lib/ordered_set.dart
+++ b/lib/ordered_set.dart
@@ -10,6 +10,9 @@ class OrderedSet<E> extends IterableMixin<E> implements Iterable<E> {
   late SplayTreeSet<List<E>> _backingSet;
   late int _length;
 
+  bool _validReverseCache = true;
+  Iterable<E> _reverseCache = Iterable.empty();
+
   // Copied from SplayTreeSet, but those are private there
   static int _dynamicCompare(dynamic a, dynamic b) => Comparable.compare(
         a as Comparable,
@@ -56,26 +59,37 @@ class OrderedSet<E> extends IterableMixin<E> implements Iterable<E> {
     return _backingSet.expand<E>((es) => es).iterator;
   }
 
-  /// Adds each element of the provided [es] to this and returns the number of
+  Iterable<E> reversed() {
+    if (!_validReverseCache) {
+      _reverseCache = toList(growable: false).reversed;
+    }
+    return _reverseCache;
+  }
+
+  /// Adds each element of the provided [elements] to this and returns the number of
   /// elements added.
   ///
   /// Since elements are always added, this should always return the length of
-  /// [es].
-  int addAll(Iterable<E> es) {
-    return es.map(add).where((e) => e).length;
+  /// [elements].
+  int addAll(Iterable<E> elements) {
+    _validReverseCache = false;
+    return elements.map(add).where((e) => e).length;
   }
 
-  /// Adds the element [e] to this, and returns wether the element was
-  /// succesfully added or not.
+  /// Adds the element [e] to this, and returns whether the element was
+  /// successfully added or not.
   ///
-  /// You can always add elements, even duplicated elemneted are added, so this
+  /// You can always add elements, even duplicated elements are added, so this
   /// always return true.
   bool add(E e) {
     _length++;
     final added = _backingSet.add([e]);
     if (!added) {
       _backingSet.lookup([e])!.add(e);
+      // TODO: Shouldn't we return false here and not add the element, to make it a proper set?
     }
+    // TODO: Moved into else if it is decided that duplicate elements are discarded.
+    _validReverseCache = false;
     return true;
   }
 
@@ -89,7 +103,7 @@ class OrderedSet<E> extends IterableMixin<E> implements Iterable<E> {
   /// [rebalanceWhere].
   /// Note: rebalancing is **not** stable.
   void rebalanceAll() {
-    final elements = toList();
+    final elements = toList(growable: false);
     clear();
     addAll(elements);
   }
@@ -102,14 +116,19 @@ class OrderedSet<E> extends IterableMixin<E> implements Iterable<E> {
   /// In general be careful with using comparing functions that can change.
   /// Note: rebalancing is **not** stable.
   void rebalanceWhere(bool Function(E element) test) {
-    final elements = removeWhere(test).toList();
+    final elements = removeWhere(test);
     addAll(elements);
   }
 
   /// Remove all elements that match the [test] condition; returns the removed
-  /// elements
+  /// elements.
   Iterable<E> removeWhere(bool Function(E element) test) {
-    return where(test).toList()..forEach(remove);
+    return where(test).toList(growable: false)..forEach(remove);
+  }
+
+  /// Remove all [elements] and returns the removed elements.
+  Iterable<E> removeAll(Iterable<E> elements) {
+    return elements.where(remove).toList(growable: false);
   }
 
   /// Remove a single element that is equal to [e].
@@ -140,12 +159,14 @@ class OrderedSet<E> extends IterableMixin<E> implements Iterable<E> {
     if (result) {
       _length--;
       _backingSet.remove(<E>[]);
+      _validReverseCache = false;
     }
     return result;
   }
 
   /// Removes all elements of this.
   void clear() {
+    _validReverseCache = false;
     _backingSet.clear();
     _length = 0;
   }

--- a/lib/queryable_ordered_set.dart
+++ b/lib/queryable_ordered_set.dart
@@ -15,7 +15,7 @@ class _CacheEntry<C, T> {
 ///
 /// You can [register] a set of queries, i.e., predefined sub-types, whose
 /// results, i.e., subsets of this set, are then cached. Since the queries
-/// have to be type checked, and types are runtime constants, this can be
+/// have to be type checks, and types are runtime constants, this can be
 /// vastly optimized.
 ///
 /// If you find yourself doing a lot of:

--- a/lib/queryable_ordered_set.dart
+++ b/lib/queryable_ordered_set.dart
@@ -15,7 +15,7 @@ class _CacheEntry<C, T> {
 ///
 /// You can [register] a set of queries, i.e., predefined sub-types, whose
 /// results, i.e., subsets of this set, are then cached. Since the queries
-/// have to be type checks, and types are runtime constants, this can be
+/// have to be type checked, and types are runtime constants, this can be
 /// vastly optimized.
 ///
 /// If you find yourself doing a lot of:
@@ -33,7 +33,7 @@ class _CacheEntry<C, T> {
 /// types; if you do so, the registration cost is payed on the first query.
 class QueryableOrderedSet<T> extends OrderedSet<T> {
   /// Controls whether running an unregistered query throws an error or
-  /// performs a just-in-time filtering.
+  /// performs just-in-time filtering.
   final bool strictMode;
   final Map<Type, _CacheEntry<T, T>> _cache = {};
 
@@ -69,7 +69,7 @@ class QueryableOrderedSet<T> extends OrderedSet<T> {
   /// except that it is O(0).
   ///
   /// Note: you *must* call [register] for every type [C] you desire to use
-  /// before calling this.
+  /// before calling this, or set [strictMode] to false.
   List<C> query<C extends T>() {
     final result = _cache[C];
     if (result == null) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,6 @@ environment:
 
 dev_dependencies:
   test: ^1.17.10
-  dart_code_metrics: ^3.2.2
-  dartdoc: ^0.42.0
+  dart_code_metrics: ^4.6.0
+  dartdoc: ^4.1.0
   coverage: ^1.0.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,10 +4,10 @@ version: 4.0.0
 homepage: https://github.com/luanpotter/ordered_set
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.14.0 <3.0.0'
 
 dev_dependencies:
-  test: ^1.16.0-nullsafety
+  test: ^1.17.10
   dart_code_metrics: ^3.2.2
   dartdoc: ^0.42.0
   coverage: ^1.0.3

--- a/test/ordered_set_test.dart
+++ b/test/ordered_set_test.dart
@@ -277,6 +277,24 @@ void main() {
         expect(a.remove(a3), true);
         expect(a.toList().join(), '**');
       });
+
+      test('removeAll', () {
+        final orderedSet = OrderedSet<ComparableObject>(
+          Comparing.on((e) => e.priority),
+        );
+
+        final a = ComparableObject(0, 'a');
+        final b = ComparableObject(1, 'b');
+        final c = ComparableObject(2, 'c');
+        final d = ComparableObject(3, 'd');
+
+        orderedSet.addAll([d, b, a, c]);
+        expect(orderedSet.removeAll([c, a]).join(), 'ca');
+        expect(orderedSet.toList().join(), 'bd');
+        orderedSet.addAll([d, b, a, c]);
+        expect(orderedSet.removeAll([d, b]).join(), 'db');
+        expect(orderedSet.toList().join(), 'abcd');
+      });
     });
 
     group('rebalancing', () {

--- a/test/ordered_set_test.dart
+++ b/test/ordered_set_test.dart
@@ -305,5 +305,41 @@ void main() {
         expect(orderedSet.toList().join(), 'cdab');
       });
     });
+
+    group('reversed', () {
+      test('reversed properly invalidates cache', () {
+        final orderedSet = OrderedSet<ComparableObject>(
+          Comparing.on((e) => e.priority),
+        );
+
+        final a = ComparableObject(0, 'a');
+        final b = ComparableObject(1, 'b');
+        final c = ComparableObject(2, 'c');
+        final d = ComparableObject(3, 'd');
+
+        orderedSet.addAll([d, b, a, c]);
+        expect(orderedSet.reversed().join(), 'dcba');
+
+        a.priority = 4;
+        expect(orderedSet.reversed().join(), 'dcba');
+        orderedSet.rebalanceWhere((e) => identical(e, a));
+        expect(orderedSet.reversed().join(), 'adcb');
+
+        b.priority = 5;
+        c.priority = -1;
+        expect(orderedSet.reversed().join(), 'adcb');
+        orderedSet.rebalanceAll();
+        expect(orderedSet.reversed().join(), 'badc');
+
+        orderedSet.remove(d);
+        expect(orderedSet.reversed().join(), 'bac');
+        orderedSet.add(d);
+        expect(orderedSet.reversed().join(), 'badc');
+        orderedSet.removeAll([a, b]);
+        expect(orderedSet.reversed().join(), 'dc');
+        orderedSet.addAll([a, b]);
+        expect(orderedSet.reversed().join(), 'badc');
+      });
+    });
   });
 }


### PR DESCRIPTION
`reversed` is cached so that it doesn't have to be recalculated all the time in flame.