### PR TITLE
refactor: Make query() return an Iterable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 6.0.0
+
+- Make `QueryableOrderedSet.query()` return an `Iterable` instead of a `List`,
+  in order to prevent hard-to-track bugs with accidental cache modification
+  from outside
+
 ## 5.0.3
 
 - Fix bug with sorting after removal of element in root bucket

--- a/lib/queryable_ordered_set.dart
+++ b/lib/queryable_ordered_set.dart
@@ -70,7 +70,7 @@ class QueryableOrderedSet<T> extends OrderedSet<T> {
   ///
   /// Note: you *must* call [register] for every type [C] you desire to use
   /// before calling this, or set [strictMode] to false.
-  List<C> query<C extends T>() {
+  Iterable<C> query<C extends T>() {
     final result = _cache[C];
     if (result == null) {
       if (strictMode) {
@@ -80,7 +80,11 @@ class QueryableOrderedSet<T> extends OrderedSet<T> {
         return query<C>();
       }
     }
-    return result.data as List<C>;
+    // We are returning the cached List itself but we cast it as an Iterable
+    // to prevent users from accidentally modifying the cache from outside.
+    // We are not using an UnmodifiableListView() or anything similar because
+    // we want to avoid creating a new object for every query.
+    return result.data as Iterable<C>;
   }
 
   /// Whether type [C] is registered as a cache

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ordered_set
 description: A simple implementation of an Ordered Set for Dart that allows multiple items with the same priority.
-version: 5.0.3
-homepage: https://github.com/luanpotter/ordered_set
+version: 6.0.0
+homepage: https://github.com/bluefireteam/ordered_set
 
 environment:
   sdk: '>=2.14.0 <3.0.0'

--- a/test/queryable_ordered_set_test.dart
+++ b/test/queryable_ordered_set_test.dart
@@ -292,11 +292,6 @@ void main() {
 
         final dogs = orderedSet.query<Dog>();
         expect(dogs, isA<Iterable<Dog>>());
-
-        // Note that the following fails, since it _is_ possible to force cast
-        // the returned value as a List.
-        // expect(dogs is List<Dog>, isFalse);
-        // expect(dogs, isNot(isA<List<Dog>>()));
       });
     });
   });

--- a/test/queryable_ordered_set_test.dart
+++ b/test/queryable_ordered_set_test.dart
@@ -278,6 +278,26 @@ void main() {
         expect(orderedSet.isRegistered<Mammal>(), isTrue);
         // A call to isRegistered without a type should always be isFalse
       });
+      test('#query returns Iterable', () {
+        final dog = Dog()..name = 'Joey';
+        final bird = Bird()..name = 'Louise';
+
+        final orderedSet = QueryableOrderedSet<Animal>(
+          comparator: Comparing.on((e) => e.name),
+        );
+        orderedSet.register<Dog>();
+
+        orderedSet.add(dog);
+        orderedSet.add(bird);
+
+        final dogs = orderedSet.query<Dog>();
+        expect(dogs, isA<Iterable<Dog>>());
+
+        // Note that the following fails, since it _is_ possible to force cast
+        // the returned value as a List.
+        // expect(dogs is List<Dog>, isFalse);
+        // expect(dogs, isNot(isA<List<Dog>>()));
+      });
     });
   });
 }


### PR DESCRIPTION
Fixes #31

I added a unit test but since it's not really testing anything important, I'm happy to remove it.

I also went ahead and upped semver, though that, too, can be removed from this PR.

cc @spydon 