### PR TITLE
Tighten type on Comparable

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,7 @@
+analyzer:
+  language:
+    strict-casts: true
+    strict-inference: true
+    strict-raw-types: true
+
 include: package:flame_lint/analysis_options.yaml

--- a/lib/comparing.dart
+++ b/lib/comparing.dart
@@ -10,7 +10,7 @@ class Comparing {
 
   /// Returns a Comparator that compares objects of type T by mapping them to
   /// Comparables.
-  static Comparator<T> on<T>(Comparable Function(T t) mapper) {
+  static Comparator<T> on<T>(Comparable<Object> Function(T t) mapper) {
     return (a, b) => mapper(a).compareTo(mapper(b));
   }
 
@@ -26,7 +26,7 @@ class Comparing {
 
   /// Join several mappers and compare in order (first the first element, then
   /// the second, and so on).
-  static Comparator<T> join<T>(List<Comparable Function(T t)> mappers) {
+  static Comparator<T> join<T>(List<Comparable<Object> Function(T t)> mappers) {
     return (a, b) {
       final r = on(mappers.first)(a, b);
       if (r == 0) {

--- a/lib/comparing.dart
+++ b/lib/comparing.dart
@@ -10,7 +10,7 @@ class Comparing {
 
   /// Returns a Comparator that compares objects of type T by mapping them to
   /// Comparables.
-  static Comparator<T> on<T>(Comparable<Object> Function(T t) mapper) {
+  static Comparator<T> on<T>(Comparable<Object?> Function(T t) mapper) {
     return (a, b) => mapper(a).compareTo(mapper(b));
   }
 
@@ -26,7 +26,8 @@ class Comparing {
 
   /// Join several mappers and compare in order (first the first element, then
   /// the second, and so on).
-  static Comparator<T> join<T>(List<Comparable<Object> Function(T t)> mappers) {
+  static Comparator<T> join<T>(
+      List<Comparable<Object?> Function(T t)> mappers) {
     return (a, b) {
       final r = on(mappers.first)(a, b);
       if (r == 0) {


### PR DESCRIPTION
This change merely enables strict typing and tightens one `Comparable<dynamic>` to `Comparable<Object>`. The effect is probably zero, though there might _theoretically_ be a miniscule performance uplift (going from nullable `dynamic` to non-nullable `Object`, possibly saving a null check or two.

I don't think this is breaking. I can't imagine anyone wanting to map something to a `Comparable` of a nullable type. But I may easily be wrong.
