### PR TITLE
fix: Optimize addAll

### DIFF
--- a/lib/ordered_set.dart
+++ b/lib/ordered_set.dart
@@ -72,7 +72,13 @@ class OrderedSet<E> extends IterableMixin<E> {
 
   /// Adds each element of the provided [elements] to this and returns the
   /// number of elements added.
-  int addAll(Iterable<E> elements) => elements.map(add).where((e) => e).length;
+  int addAll(Iterable<E> elements) {
+    final lengthBefore = _length;
+    for (final element in elements) {
+      add(element);
+    }
+    return _length - lengthBefore;
+  }
 
   /// Adds the element [e] to this, and returns whether the element was
   /// added or not. If the element already exists in the collection, it isn't


### PR DESCRIPTION
Optimize `addAll` to not go through the elements again to get the length.