### PR TITLE
perf: Improve comprehensive benchmark to be less finicky

### DIFF
--- a/benchmark/comprehensive_benchmark.dart
+++ b/benchmark/comprehensive_benchmark.dart
@@ -4,8 +4,9 @@ import 'package:benchmark_harness/benchmark_harness.dart';
 import 'package:ordered_set/comparing.dart';
 import 'package:ordered_set/ordered_set.dart';
 
-const _maxStartingOperations = 1000;
-const _maxElement = 1000;
+const _maxOperations = 2500;
+const _maxElement = 10000;
+const _startingSetSize = 500;
 
 class ComprehensiveBenchmark extends BenchmarkBase {
   final Random r;
@@ -67,15 +68,22 @@ class _Runtime {
   }
 
   void iterate() {
-    while (_totalOperations == 0 || _queue.isNotEmpty) {
-      if (_totalOperations < _maxStartingOperations) {
-        for (var i = 0; i < r.nextInt(3) + 2; i++) {
-          _queueOp(_randomOperation());
-        }
-      }
+    _populateSet();
 
+    while (_totalOperations < _maxOperations) {
+      final operation = _randomOperation();
+      _queueOp(operation);
+    }
+
+    while (_queue.isNotEmpty) {
       final op = _queue.removeAt(0);
       op.execute(this, _set).forEach(_queueOp);
+    }
+  }
+
+  void _populateSet() {
+    for (var i = 0; i < _startingSetSize; i++) {
+      _queueOp(_AddOperation(_randomElement()));
     }
   }
 


### PR DESCRIPTION
I've noticed that the current implementation, while a commendable goal, was too delicate in the input size.

For example, the [example of a bad PR](https://github.com/bluefireteam/ordered_set/pull/50) ran the "bad" version of the code for 6h and then got timed out by GitHub.

Even playing locally with the max operations constant shows me that sometimes a 20% change in the number is the difference between faster than the other benchmark to "infinite" (infinite defined as more time than I had patience to wait).

This is an attempt to make it more linearly dependent on the max size, as well as calibrating the constants, so the total runtime is more manageable.

I will test this by rebasing the "bad PR example" once merged.

---

That all being said I am very open to suggestions on other alternatives for good benchmarks, this was my idea to try to simulate real life behaviours with concurrent modifications and such, but it has become slightly Frankenstein's monster-esque.