### PR TITLE
perf: Configure dart-benchmark-action to allow for "no-benchmark" ignore tag

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,5 +14,6 @@ jobs:
     - uses: luanpotter/dart-benchmark-action@v0.1.10
       with:
         paths: "."
+        ignore-tag: "no-benchmark"
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR itself is a test if the label is working with the bot.