### PR TITLE
feat!: Introduce new `PriorityOrderedSet`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 [![Build Status](https://github.com/flame-engine/flame/workflows/cicd/badge.svg?branch=main&event=push)](https://github.com/bluefireteam/ordered_set/actions/workflows/cicd.yml)
 [![Coverage Status](https://coveralls.io/repos/github/bluefireteam/ordered_set/badge.svg?branch=main)](https://coveralls.io/github/bluefireteam/ordered_set?branch=main)
 
-A simple implementation for an ordered set for Dart.
+A simple implementation for an Ordered Set for Dart.
 
-It accepts a compare function that compares items for their priority.
+It accepts either a comparator function that compares items for their priority or a mapper function that maps items to their priority.
 
-Unlike Dart's [SplayTreeSet](https://api.dartlang.org/stable/1.24.3/dart-collection/SplayTreeSet/SplayTreeSet.html), it allows for several different elements with the same priority to be added.
+Unlike Dart's [SplayTreeSet](https://api.dart.dev/dart-collection/SplayTreeSet-class.html) or [SplayTreeMap](https://api.dart.dev/dart-collection/SplayTreeMap-class.html) classes, it allows for several different elements with the same "priority" to be added.
 
-It also implements [Iterable](https://api.dartlang.org/stable/1.24.3/dart-core/Iterable-class.html), so you can iterate it in O(n).
+It also implements [Iterable](https://api.dart.dev/dart-core/Iterable-class.html), allowing you to iterate the contents (in order) in O(n) (no additional overhead).
 
 ## Usage
 
@@ -20,27 +20,64 @@ A simple usage example:
   import 'package:ordered_set/ordered_set.dart';
 
   main() {
-    final items = OrderedSet<int>();
+    final items = OrderedSet.simple<num, int>();
     items.add(2);
     items.add(1);
     print(items.toList()); // [1, 2]
   }
 ```
 
+But it can accept multiple items with the same priority:
+
+```dart
+  import 'package:ordered_set/ordered_set.dart';
+
+  main() {
+    final items = OrderedSet.mapping<String, Person>((p) => p.name);
+    items.add(Person('Alice', 'Engineering'));
+    items.add(Person('Bob', 'Accounting'));
+    items.add(Person('Alice', 'Marketing'));
+    print(items.toList()); // [Alice, Alice, Bob]
+  }
+```
+
 ## Comparing
 
-In order to assist the creation of OrderedSet's, there is a Comparing class to easily create Comparables:
+In order to assist the creation of `Comparator`s, the `Comparing` class can be used:
 
 ```dart
   // sort by name length
-  final people = OrderedSet<Person>(Comparing.on((p) => p.name.length));
+  final people = OrderedSet.comparing<Person>(Comparing.on((p) => p.name.length));
 
   // sort by name desc
-  final people = OrderedSet<Person>(Comparing.reverse(Comparing.on((p) => p.name)));
+  final people = OrderedSet.comparing<Person>(Comparing.reverse(Comparing.on((p) => p.name)));
 
   // sort by role and then by name
-  final people = OrderedSet<Person>(Comparing.join([(p) => p.role, (p) => p.name]));
+  final people = OrderedSet.comparing<Person>(Comparing.join([(p) => p.role, (p) => p.name]));
 ```
+
+Note that you could instead just create a `MappingOrderedSet` instead:
+
+```dart
+  final people = OrderedSet.mapping<num, Person>((p) => p.name.length);
+  // ...
+```
+
+## Mapping vs Comparing vs Queryable
+
+There are three main implementations of the `OrderedSet` interface:
+
+* `ComparingOrderedSet`: the simplest implementation, takes in a `Comparator` and does not cache priorities. It uses Dart's `SplayTreeSet` as a backing implementation.
+* `MappingOrderedSet`: a slightly more advanced implementation that takes in a mapper function (maps elements to their priorities) and caches them. It uses Dart's `SplayTreeMap` as a backing implementation.
+* `QueryableOrderedSet`: a simple wrapper over either `OrderedSet` that allows for O(1) type queries; if you find yourself doing `.whereType<T>()` a lot, you should consider using this.
+
+In order to create an `OrderedSet`, however, you can just use the static methods on the interface itself:
+
+* `comparing<E>([comparator])`: creates a `ComparingOrderedSet` with the given `Comparator`.
+* `mapping<K, E>([mapper])`: creates a `MappingOrderedSet` with the given mapper function.
+* `comparable<K, E>()`: if `E extends Comparable<K>`, this is a simpler way of creating a `MappingOrderedSet` with identity mapping.
+* `simple<E>()`: if `E extends Comparable<E>`, this is an even simpler way of creating a `MappingOrderedSet` with identity mapping.
+* `queryable<E>(orderedSet)`: wraps the given `OrderedSet` into a `QueryableOrderedSet`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,15 @@
 
 A simple implementation for an Ordered Set for Dart.
 
-It accepts either a comparator function that compares items for their priority or a mapper function that maps items to their priority.
+It accepts either a comparator function that compares items for their priority or a mapper function
+that maps items to their priority.
 
-Unlike Dart's [SplayTreeSet](https://api.dart.dev/dart-collection/SplayTreeSet-class.html) or [SplayTreeMap](https://api.dart.dev/dart-collection/SplayTreeMap-class.html) classes, it allows for several different elements with the same "priority" to be added.
+Unlike Dart's [SplayTreeSet](https://api.dart.dev/dart-collection/SplayTreeSet-class.html) or
+[SplayTreeMap](https://api.dart.dev/dart-collection/SplayTreeMap-class.html) classes, it allows for
+several different elements with the same "priority" to be added.
 
-It also implements [Iterable](https://api.dart.dev/dart-core/Iterable-class.html), allowing you to iterate the contents (in order) in O(n) (no additional overhead).
+It also implements [Iterable](https://api.dart.dev/dart-core/Iterable-class.html), allowing you to
+iterate the contents (in order) in O(n) (no additional overhead).
 
 ## Usage
 
@@ -67,18 +71,29 @@ Note that you could instead just create a `MappingOrderedSet` instead:
 
 There are three main implementations of the `OrderedSet` interface:
 
-* `ComparingOrderedSet`: the simplest implementation, takes in a `Comparator` and does not cache priorities. It uses Dart's `SplayTreeSet` as a backing implementation.
-* `MappingOrderedSet`: a slightly more advanced implementation that takes in a mapper function (maps elements to their priorities) and caches them. It uses Dart's `SplayTreeMap` as a backing implementation.
-* `QueryableOrderedSet`: a simple wrapper over either `OrderedSet` that allows for O(1) type queries; if you find yourself doing `.whereType<T>()` a lot, you should consider using this.
+* `ComparingOrderedSet`: the simplest implementation, takes in a `Comparator` and does not cache
+   priorities. It uses Dart's `SplayTreeSet` as a backing implementation.
+* `MappingOrderedSet`: a slightly more advanced implementation that takes in a mapper function
+   (maps elements to their priorities) and caches them. It uses Dart's `SplayTreeMap` as a backing
+   implementation.
+* `QueryableOrderedSet`: a simple wrapper over either `OrderedSet` that allows for O(1) type
+   queries; if you find yourself doing `.whereType<T>()` a lot, you should consider using this.
 
-In order to create an `OrderedSet`, however, you can just use the static methods on the interface itself:
+In order to create an `OrderedSet`, however, you can just use the static methods on the interface
+itself:
 
-* `comparing<E>([comparator])`: creates a `ComparingOrderedSet` with the given `Comparator`.
-* `mapping<K, E>([mapper])`: creates a `MappingOrderedSet` with the given mapper function.
-* `comparable<K, E>()`: if `E extends Comparable<K>`, this is a simpler way of creating a `MappingOrderedSet` with identity mapping.
-* `simple<E>()`: if `E extends Comparable<E>`, this is an even simpler way of creating a `MappingOrderedSet` with identity mapping.
-* `queryable<E>(orderedSet)`: wraps the given `OrderedSet` into a `QueryableOrderedSet`.
+* `OrderedSet.comparing<E>([comparator])`: creates a `ComparingOrderedSet` with the given
+  `Comparator`.
+* `OrderedSet.mapping<K, E>([mapper])`: creates a `MappingOrderedSet` with the given mapper
+  function.
+* `OrderedSet.comparable<K, E>()`: if `E extends Comparable<K>`, this is a simpler way of creating
+  a `MappingOrderedSet` with identity mapping.
+* `OrderedSet.simple<E>()`: if `E extends Comparable<E>`, this is an even simpler way of creating
+  a `MappingOrderedSet` with identity mapping.
+* `OrderedSet.queryable<E>(orderedSet)`: wraps the given `OrderedSet` into a `QueryableOrderedSet`.
 
 ## Contributing
 
-All contributions are very welcome! Please feel free to create Issues, help us with PR's or comment your suggestions, feature requests, bugs, et cetera. Give us a star if you liked it!
+All contributions are very welcome! Please feel free to create Issues, help us with PR's or comment
+your suggestions, feature requests, bugs, et cetera. Give us a star if you liked it!
+

--- a/benchmark/benchmarks/insertion_and_removal_benchmark.dart
+++ b/benchmark/benchmarks/insertion_and_removal_benchmark.dart
@@ -11,7 +11,7 @@ const _iterationAmount = 1000;
 class InsertionAndRemovalBenchmark extends BenchmarkBase {
   final Random r;
   final OrderedSet<ComparableObject> set;
-  late final Map<int, ComparableObject> objects;
+  final Map<int, ComparableObject> objects;
 
   InsertionAndRemovalBenchmark({
     required String name,
@@ -24,9 +24,11 @@ class InsertionAndRemovalBenchmark extends BenchmarkBase {
 
   @override
   void setup() {
-    objects = {
+    objects.clear();
+    objects.addAll({
       for (var i = 0; i < _iterationAmount; i++) i: ComparableObject(i, '$i'),
-    };
+    });
+    set.clear();
   }
 
   @override

--- a/benchmark/benchmarks/insertion_and_removal_benchmark.dart
+++ b/benchmark/benchmarks/insertion_and_removal_benchmark.dart
@@ -1,23 +1,29 @@
+import 'dart:math';
+
 import 'package:benchmark_harness/benchmark_harness.dart';
 import 'package:ordered_set/ordered_set.dart';
 
-import '../test/comparable_object.dart';
+import '../../test/comparable_object.dart';
+import '../types.dart';
 
 const _iterationAmount = 1000;
 
 class InsertionAndRemovalBenchmark extends BenchmarkBase {
-  late final OrderedSet<ComparableObject> set;
+  final Random r;
+  final OrderedSet<ComparableObject> set;
   late final Map<int, ComparableObject> objects;
 
-  InsertionAndRemovalBenchmark() : super('Insertion and Removal Benchmark');
-
-  static void main() {
-    InsertionAndRemovalBenchmark().report();
-  }
+  InsertionAndRemovalBenchmark({
+    required String name,
+    required int seed,
+    required Producer<ComparableObject> producer,
+  })  : r = Random(seed),
+        set = producer((e) => e.priority),
+        objects = {},
+        super('Insertion and Removal Benchmark - $name');
 
   @override
   void setup() {
-    set = OrderedSet<ComparableObject>();
     objects = {
       for (var i = 0; i < _iterationAmount; i++) i: ComparableObject(i, '$i'),
     };

--- a/benchmark/benchmarks/iteration_benchmark.dart
+++ b/benchmark/benchmarks/iteration_benchmark.dart
@@ -22,6 +22,7 @@ class IterationBenchmark extends BenchmarkBase {
 
   @override
   void setup() {
+    set.clear();
     for (var i = 0; i < _iterationAmount; i++) {
       final l = (10 + sqrt(i)).floor();
       for (var j = 0; j <= l; j++) {

--- a/benchmark/benchmarks/iteration_benchmark.dart
+++ b/benchmark/benchmarks/iteration_benchmark.dart
@@ -3,22 +3,25 @@ import 'dart:math';
 import 'package:benchmark_harness/benchmark_harness.dart';
 import 'package:ordered_set/ordered_set.dart';
 
-import '../test/comparable_object.dart';
+import '../../test/comparable_object.dart';
+import '../types.dart';
 
 const _iterationAmount = 1000;
 
 class IterationBenchmark extends BenchmarkBase {
-  late final OrderedSet<ComparableObject> set;
+  final Random r;
+  final OrderedSet<ComparableObject> set;
 
-  IterationBenchmark() : super('Iteration Benchmark');
-
-  static void main() {
-    IterationBenchmark().report();
-  }
+  IterationBenchmark({
+    required String name,
+    required int seed,
+    required Producer<ComparableObject> producer,
+  })  : r = Random(seed),
+        set = producer((e) => e.priority),
+        super('Iteration Benchmark - $name');
 
   @override
   void setup() {
-    set = OrderedSet();
     for (var i = 0; i < _iterationAmount; i++) {
       final l = (10 + sqrt(i)).floor();
       for (var j = 0; j <= l; j++) {

--- a/benchmark/main.dart
+++ b/benchmark/main.dart
@@ -1,9 +1,40 @@
-import 'comprehensive_benchmark.dart';
-import 'insertion_and_removal_benchmark.dart';
-import 'iteration_benchmark.dart';
+import 'package:ordered_set/comparing.dart';
+import 'package:ordered_set/ordered_set.dart';
+
+import 'benchmarks/comprehensive_benchmark.dart';
+import 'benchmarks/insertion_and_removal_benchmark.dart';
+import 'benchmarks/iteration_benchmark.dart';
+import 'types.dart';
 
 void main() {
-  IterationBenchmark.main();
-  InsertionAndRemovalBenchmark.main();
-  ComprehensiveBenchmark.main();
+  OrderedSet<K> comparing<K>(Mapper<K> mapper) {
+    return OrderedSet.comparing<K>(Comparing.on(mapper));
+  }
+
+  OrderedSet<K> priority<K>(Mapper<K> mapper) {
+    return OrderedSet.mapping<num, K>(mapper);
+  }
+
+  final producers = {
+    'Comparing': comparing,
+    'Priority': priority,
+  };
+
+  for (final MapEntry(key: name, value: producer) in producers.entries) {
+    IterationBenchmark(
+      name: name,
+      seed: 42690,
+      producer: producer,
+    ).report();
+    InsertionAndRemovalBenchmark(
+      name: name,
+      seed: 42690,
+      producer: producer,
+    ).report();
+    ComprehensiveBenchmark(
+      name: name,
+      seed: 42690,
+      producer: producer,
+    ).report();
+  }
 }

--- a/benchmark/types.dart
+++ b/benchmark/types.dart
@@ -1,0 +1,4 @@
+import 'package:ordered_set/ordered_set.dart';
+
+typedef Mapper<K> = int Function(K);
+typedef Producer<K> = OrderedSet<K> Function(Mapper<K>);

--- a/example/ordered_set_example.dart
+++ b/example/ordered_set_example.dart
@@ -4,12 +4,12 @@ import 'package:ordered_set/comparing.dart';
 import 'package:ordered_set/ordered_set.dart';
 
 void main() {
-  final items = OrderedSet<int>();
+  final items = OrderedSet.comparing<int>();
   items.add(2);
   items.add(1);
   print(items.toList()); // [1, 2]
 
-  final a = OrderedSet<Person>((a, b) => a.age - b.age);
+  final a = OrderedSet.comparing<Person>((a, b) => a.age - b.age);
   a.add(Person(12, 'Klaus'));
   a.add(Person(1, 'Sunny'));
   a.add(Person(14, 'Violet'));
@@ -24,10 +24,18 @@ void main() {
 
   // use Comparing for simpler creation:
   // sort by age desc and then name asc
-  final b = OrderedSet<Person>(Comparing.join([(p) => -p.age, (p) => p.name]));
+  final b = OrderedSet.comparing<Person>(
+    Comparing.join([(p) => -p.age, (p) => p.name]),
+  );
   b.addAll(a.toList());
   print(b.toList().map((e) => e.name));
   // Violet, Duncan, Isadora, Quigley, Klaus, Sunny
+
+  // or use the PriorityOrderedSet for static priorities
+  final c = OrderedSet.mapping<num, Person>((p) => p.age);
+  c.addAll(a.toList());
+  print(c.toList().map((e) => e.name));
+  // Sunny, Klaus, Isadora, Duncan, Quigley, Violet
 }
 
 class Person {

--- a/lib/comparing_ordered_set.dart
+++ b/lib/comparing_ordered_set.dart
@@ -1,0 +1,162 @@
+import 'dart:collection';
+
+import 'package:ordered_set/ordered_set.dart';
+import 'package:ordered_set/priority_ordered_set.dart';
+
+/// A simple implementation of [OrderedSet] that uses a [SplayTreeSet] as the
+/// backing store.
+///
+/// This does not store the elements priorities, so it is susceptible to race
+/// conditions if priorities are changed while iterating.
+/// For a safer implementation, use [PriorityOrderedSet].
+class ComparingOrderedSet<E> extends OrderedSet<E> {
+  // If the default implementation of `Set` changes from `LinkedHashSet` to
+  // something else that isn't ordered we'll have to change this to explicitly
+  // be `LinkedHashSet` (or some other data structure that preserves order).
+  late SplayTreeSet<Set<E>> _backingSet;
+  late int _length;
+
+  bool _validReverseCache = true;
+  Iterable<E> _reverseCache = const Iterable.empty();
+
+  // Copied from SplayTreeSet, but those are private there
+  static int _dynamicCompare(dynamic a, dynamic b) => Comparable.compare(
+        a as Comparable,
+        b as Comparable,
+      );
+  static Comparator<K> _defaultCompare<K>() {
+    const Object compare = Comparable.compare;
+    if (compare is Comparator<K>) {
+      return compare;
+    }
+    return _dynamicCompare;
+  }
+
+  /// Creates a new [OrderedSet] with the given compare function.
+  ///
+  /// If the [compare] function is omitted, it defaults to [Comparable.compare],
+  /// and the elements must be comparable.
+  ComparingOrderedSet([int Function(E e1, E e2)? compare]) {
+    final comparator = compare ?? _defaultCompare<E>();
+    _backingSet = SplayTreeSet<LinkedHashSet<E>>((Set<E> l1, Set<E> l2) {
+      if (l1.isEmpty) {
+        if (l2.isEmpty) {
+          return 0;
+        }
+        return -1;
+      }
+      if (l2.isEmpty) {
+        return 1;
+      }
+      return comparator(l1.first, l2.first);
+    });
+    _length = 0;
+  }
+
+  @override
+  int get length => _length;
+
+  @override
+  Iterator<E> get iterator {
+    return _OrderedSetIterator<E>(this);
+  }
+
+  @override
+  Iterable<E> reversed() {
+    if (!_validReverseCache) {
+      _reverseCache = toList(growable: false).reversed;
+    }
+    return _reverseCache;
+  }
+
+  @override
+  bool add(E e) {
+    final elementSet = {e};
+    var added = _backingSet.add(elementSet);
+    final isRootSet = added;
+    if (!isRootSet) {
+      added = _backingSet.lookup(elementSet)!.add(e);
+    }
+    if (added) {
+      _length++;
+      _validReverseCache = false;
+    }
+    return added;
+  }
+
+  @override
+  void rebalanceAll() {
+    final elements = toList(growable: false);
+    clear();
+    addAll(elements);
+  }
+
+  @override
+  void rebalanceWhere(bool Function(E element) test) {
+    final elements = removeWhere(test);
+    addAll(elements);
+  }
+
+  @override
+  bool remove(E e) {
+    var bucket = _backingSet.lookup({e});
+    if (bucket == null || !bucket.contains(e)) {
+      // We need a fallback in case [e] has changed and it's no longer found by
+      // lookup. Note: changing priorities will leave the splay set on an
+      // unknown state; other methods might not work. You must call rebalance to
+      // make sure the state is consistent. This is just for convenient usage by
+      // the rebalancing method itself.
+      final possibleBuckets = _backingSet
+          .where((bucket) => bucket.any((element) => identical(element, e)));
+      if (possibleBuckets.isNotEmpty) {
+        bucket = possibleBuckets.first;
+      }
+    }
+    if (bucket == null) {
+      return false;
+    }
+    final result = bucket.remove(e);
+    if (result) {
+      _length--;
+      // If the removal resulted in an empty bucket, remove the bucket as well.
+      _backingSet.remove(<E>{});
+      _validReverseCache = false;
+    }
+    return result;
+  }
+
+  @override
+  void clear() {
+    _validReverseCache = false;
+    _backingSet.clear();
+    _length = 0;
+  }
+}
+
+class _OrderedSetIterator<E> implements Iterator<E> {
+  final Iterator<Set<E>> _iterator;
+  Iterator<E>? _innerIterator;
+
+  _OrderedSetIterator(ComparingOrderedSet<E> orderedSet)
+      : _iterator = orderedSet._backingSet.iterator;
+
+  @override
+  E get current => _innerIterator!.current;
+
+  @pragma('vm:prefer-inline')
+  @pragma('wasm:prefer-inline')
+  @override
+  bool moveNext() {
+    if (_innerIterator?.moveNext() != true) {
+      final result = _iterator.moveNext();
+
+      if (!result) {
+        return false;
+      }
+
+      _innerIterator = _iterator.current.iterator;
+      return _innerIterator!.moveNext();
+    }
+    return true;
+  }
+}

--- a/lib/comparing_ordered_set.dart
+++ b/lib/comparing_ordered_set.dart
@@ -58,7 +58,7 @@ class ComparingOrderedSet<E> extends OrderedSet<E> {
 
   @override
   Iterator<E> get iterator {
-    return _OrderedSetIterator<E>(this);
+    return _ComparingOrderedSetIterator<E>(this);
   }
 
   @override
@@ -133,11 +133,11 @@ class ComparingOrderedSet<E> extends OrderedSet<E> {
   }
 }
 
-class _OrderedSetIterator<E> implements Iterator<E> {
+class _ComparingOrderedSetIterator<E> implements Iterator<E> {
   final Iterator<Set<E>> _iterator;
   Iterator<E>? _innerIterator;
 
-  _OrderedSetIterator(ComparingOrderedSet<E> orderedSet)
+  _ComparingOrderedSetIterator(ComparingOrderedSet<E> orderedSet)
       : _iterator = orderedSet._backingSet.iterator;
 
   @override
@@ -155,7 +155,8 @@ class _OrderedSetIterator<E> implements Iterator<E> {
       }
 
       _innerIterator = _iterator.current.iterator;
-      return _innerIterator!.moveNext();
+      _innerIterator!.moveNext();
+      return true;
     }
     return true;
   }

--- a/lib/comparing_ordered_set.dart
+++ b/lib/comparing_ordered_set.dart
@@ -1,14 +1,15 @@
 import 'dart:collection';
 
+import 'package:ordered_set/mapping_ordered_set.dart';
 import 'package:ordered_set/ordered_set.dart';
-import 'package:ordered_set/priority_ordered_set.dart';
+import 'package:ordered_set/ordered_set_iterator.dart';
 
 /// A simple implementation of [OrderedSet] that uses a [SplayTreeSet] as the
 /// backing store.
 ///
 /// This does not store the elements priorities, so it is susceptible to race
 /// conditions if priorities are changed while iterating.
-/// For a safer implementation, use [PriorityOrderedSet].
+/// For a safer implementation, use [MappingOrderedSet].
 class ComparingOrderedSet<E> extends OrderedSet<E> {
   // If the default implementation of `Set` changes from `LinkedHashSet` to
   // something else that isn't ordered we'll have to change this to explicitly
@@ -58,7 +59,7 @@ class ComparingOrderedSet<E> extends OrderedSet<E> {
 
   @override
   Iterator<E> get iterator {
-    return _ComparingOrderedSetIterator<E>(this);
+    return OrderedSetIterator.from(_backingSet.iterator);
   }
 
   @override
@@ -130,34 +131,5 @@ class ComparingOrderedSet<E> extends OrderedSet<E> {
     _validReverseCache = false;
     _backingSet.clear();
     _length = 0;
-  }
-}
-
-class _ComparingOrderedSetIterator<E> implements Iterator<E> {
-  final Iterator<Set<E>> _iterator;
-  Iterator<E>? _innerIterator;
-
-  _ComparingOrderedSetIterator(ComparingOrderedSet<E> orderedSet)
-      : _iterator = orderedSet._backingSet.iterator;
-
-  @override
-  E get current => _innerIterator!.current;
-
-  @pragma('vm:prefer-inline')
-  @pragma('wasm:prefer-inline')
-  @override
-  bool moveNext() {
-    if (_innerIterator?.moveNext() != true) {
-      final result = _iterator.moveNext();
-
-      if (!result) {
-        return false;
-      }
-
-      _innerIterator = _iterator.current.iterator;
-      _innerIterator!.moveNext();
-      return true;
-    }
-    return true;
   }
 }

--- a/lib/ordered_set.dart
+++ b/lib/ordered_set.dart
@@ -1,7 +1,7 @@
 import 'dart:collection';
 
 import 'package:ordered_set/comparing_ordered_set.dart';
-import 'package:ordered_set/priority_ordered_set.dart';
+import 'package:ordered_set/mapping_ordered_set.dart';
 import 'package:ordered_set/queryable_ordered_set.dart';
 
 /// A simple interface of an ordered set for Dart.
@@ -60,7 +60,7 @@ abstract class OrderedSet<E> extends IterableMixin<E> {
   ///
   ///     set.removeWhere((a) => a == e);
   ///
-  /// Note: when using the [PriorityOrderedSet] implementation, this will only
+  /// Note: when using the [MappingOrderedSet] implementation, this will only
   /// work if the element's priority hasn't changed since last rebalance.
   bool remove(E e);
 
@@ -92,28 +92,28 @@ abstract class OrderedSet<E> extends IterableMixin<E> {
     return ComparingOrderedSet<E>(compare);
   }
 
-  /// Creates an instance of [OrderedSet] using the [PriorityOrderedSet]
-  /// implementation and the provided [priority] mapping function.
-  static PriorityOrderedSet<K, E> mapping<K extends Comparable<K>, E>(
-    K Function(E a) priority,
+  /// Creates an instance of [OrderedSet] using the [MappingOrderedSet]
+  /// implementation and the provided [mappingFunction].
+  static MappingOrderedSet<K, E> mapping<K extends Comparable<K>, E>(
+    K Function(E a) mappingFunction,
   ) {
-    return PriorityOrderedSet(priority);
+    return MappingOrderedSet(mappingFunction);
   }
 
   /// Creates an instance of [OrderedSet] for items that are already
-  /// [Comparable] using the [PriorityOrderedSet] implementation.
+  /// [Comparable] using the [MappingOrderedSet] implementation.
   /// Use this for classes that implement [Comparable] of a different class.
   /// Equivalent to `mapping<K, E>((a) => a)`.
-  static PriorityOrderedSet<K, E>
+  static MappingOrderedSet<K, E>
       comparable<K extends Comparable<K>, E extends K>() {
     return mapping<K, E>((a) => a);
   }
 
   /// Creates an instance of [OrderedSet] for items that are already
-  /// [Comparable] of themselves, using the [PriorityOrderedSet] implementation.
+  /// [Comparable] of themselves, using the [MappingOrderedSet] implementation.
   /// Use this for classes that implement [Comparable] of themselves.
   /// Equivalent to `mapping<K, K>((a) => a)`.
-  static PriorityOrderedSet<E, E> simple<E extends Comparable<E>>() {
+  static MappingOrderedSet<E, E> simple<E extends Comparable<E>>() {
     return comparable<E, E>();
   }
 

--- a/lib/ordered_set.dart
+++ b/lib/ordered_set.dart
@@ -1,100 +1,32 @@
 import 'dart:collection';
 
-/// A simple implementation for an ordered set for Dart.
+import 'package:ordered_set/comparing_ordered_set.dart';
+import 'package:ordered_set/priority_ordered_set.dart';
+import 'package:ordered_set/queryable_ordered_set.dart';
+
+/// A simple interface of an ordered set for Dart.
 ///
-/// It accepts a compare function that compares items for their priority. Unlike
+/// It accepts some way of comparing items for their priority. Unlike
 /// [SplayTreeSet], it allows for several different elements with the same
 /// priority to be added. It also implements [Iterable], so you can iterate it
 /// in O(n).
-class OrderedSet<E> extends IterableMixin<E> {
-  // If the default implementation of `Set` changes from `LinkedHashSet` to
-  // something else that isn't ordered we'll have to change this to explicitly
-  // be `LinkedHashSet` (or some other data structure that preserves order).
-  late SplayTreeSet<Set<E>> _backingSet;
-  late int _length;
-
-  bool _validReverseCache = true;
-  Iterable<E> _reverseCache = const Iterable.empty();
-
-  // Copied from SplayTreeSet, but those are private there
-  static int _dynamicCompare(dynamic a, dynamic b) => Comparable.compare(
-        a as Comparable,
-        b as Comparable,
-      );
-  static Comparator<K> _defaultCompare<K>() {
-    const Object compare = Comparable.compare;
-    if (compare is Comparator<K>) {
-      return compare;
-    }
-    return _dynamicCompare;
-  }
-
-  /// Creates a new [OrderedSet] with the given compare function.
-  ///
-  /// If the [compare] function is omitted, it defaults to [Comparable.compare],
-  /// and the elements must be comparable.
-  OrderedSet([int Function(E e1, E e2)? compare]) {
-    final comparator = compare ?? _defaultCompare<E>();
-    _backingSet = SplayTreeSet<LinkedHashSet<E>>((Set<E> l1, Set<E> l2) {
-      if (l1.isEmpty) {
-        if (l2.isEmpty) {
-          return 0;
-        }
-        return -1;
-      }
-      if (l2.isEmpty) {
-        return 1;
-      }
-      return comparator(l1.first, l2.first);
-    });
-    _length = 0;
-  }
-
-  /// Gets the current length of this.
-  ///
-  /// Returns the cached length of this, in O(1). This is the full length, i.e.,
-  /// the sum of the lengths of each bucket.
-  @override
-  int get length => _length;
-
-  @override
-  Iterator<E> get iterator {
-    return _OrderedSetIterator<E>(this);
-  }
-
-  /// The tree's elements in reversed order, cached when possible.
-  Iterable<E> reversed() {
-    if (!_validReverseCache) {
-      _reverseCache = toList(growable: false).reversed;
-    }
-    return _reverseCache;
-  }
-
-  /// Adds each element of the provided [elements] to this and returns the
-  /// number of elements added.
-  int addAll(Iterable<E> elements) {
-    final lengthBefore = _length;
-    for (final element in elements) {
-      add(element);
-    }
-    return _length - lengthBefore;
-  }
+abstract class OrderedSet<E> extends IterableMixin<E> {
+  /// The tree's elements in reversed order; should be cached when possible.
+  Iterable<E> reversed();
 
   /// Adds the element [e] to this, and returns whether the element was
   /// added or not. If the element already exists in the collection, it isn't
   /// added.
-  bool add(E e) {
-    final elementSet = {e};
-    var added = _backingSet.add(elementSet);
-    final isRootSet = added;
-    if (!isRootSet) {
-      added = _backingSet.lookup(elementSet)!.add(e);
+  bool add(E e);
+
+  /// Adds each element of the provided [elements] to this and returns the
+  /// number of elements added.
+  int addAll(Iterable<E> elements) {
+    final lengthBefore = length;
+    for (final element in elements) {
+      add(element);
     }
-    if (added) {
-      _length++;
-      _validReverseCache = false;
-    }
-    return added;
+    return length - lengthBefore;
   }
 
   /// Allows you to rebalance the whole tree. If you are dealing with
@@ -106,11 +38,9 @@ class OrderedSet<E> extends IterableMixin<E> {
   /// If only a few known elements need rebalancing, you can use
   /// [rebalanceWhere].
   /// Note: rebalancing is **not** stable.
-  void rebalanceAll() {
-    final elements = toList(growable: false);
-    clear();
-    addAll(elements);
-  }
+  /// Note: this is a potentially expensive operation, and should be used
+  /// sparingly.
+  void rebalanceAll();
 
   /// Allows you to rebalance only a portion of the tree. If you are dealing
   /// with non-deterministic compare functions, you probably need to consider
@@ -119,10 +49,20 @@ class OrderedSet<E> extends IterableMixin<E> {
   /// you can use this instead of [rebalanceAll].
   /// In general be careful with using comparing functions that can change.
   /// Note: rebalancing is **not** stable.
-  void rebalanceWhere(bool Function(E element) test) {
-    final elements = removeWhere(test);
-    addAll(elements);
-  }
+  /// Note: this is a potentially expensive operation, and should be used
+  /// sparingly.
+  void rebalanceWhere(bool Function(E element) test);
+
+  /// Remove a single element that is equal to [e].
+  ///
+  /// If there are multiple elements identical to [e], only the first will be
+  /// removed. To remove all, use something like:
+  ///
+  ///     set.removeWhere((a) => a == e);
+  ///
+  /// Note: when using the [PriorityOrderedSet] implementation, this will only
+  /// work if the element's priority hasn't changed since last rebalance.
+  bool remove(E e);
 
   /// Remove all elements that match the [test] condition; returns the removed
   /// elements.
@@ -138,72 +78,51 @@ class OrderedSet<E> extends IterableMixin<E> {
   /// Removes the element at [index].
   bool removeAt(int index) => remove(elementAt(index));
 
-  /// Remove a single element that is equal to [e].
-  ///
-  /// If there are multiple elements identical to [e], only the first will be
-  /// removed. To remove all, use something like:
-  ///
-  ///     set.removeWhere((a) => a == e);
-  ///
-  bool remove(E e) {
-    var bucket = _backingSet.lookup({e});
-    if (bucket == null || !bucket.contains(e)) {
-      // We need a fallback in case [e] has changed and it's no longer found by
-      // lookup. Note: changing priorities will leave the splay set on an
-      // unknown state; other methods might not work. You must call rebalance to
-      // make sure the state is consistent. This is just for convenient usage by
-      // the rebalancing method itself.
-      final possibleBuckets = _backingSet
-          .where((bucket) => bucket.any((element) => identical(element, e)));
-      if (possibleBuckets.isNotEmpty) {
-        bucket = possibleBuckets.first;
-      }
-    }
-    if (bucket == null) {
-      return false;
-    }
-    final result = bucket.remove(e);
-    if (result) {
-      _length--;
-      // If the removal resulted in an empty bucket, remove the bucket as well.
-      _backingSet.remove(<E>{});
-      _validReverseCache = false;
-    }
-    return result;
-  }
-
   /// Removes all elements of this.
-  void clear() {
-    _validReverseCache = false;
-    _backingSet.clear();
-    _length = 0;
+  void clear();
+
+  /// Creates an instance of [OrderedSet] using the [ComparingOrderedSet]
+  /// implementation and the provided [compare] function.
+  ///
+  /// This implementation will not store component priorities, so it is
+  /// susceptible to race conditions if priorities are changed while iterating.
+  static ComparingOrderedSet<E> comparing<E>([
+    int Function(E a, E b)? compare,
+  ]) {
+    return ComparingOrderedSet<E>(compare);
   }
-}
 
-class _OrderedSetIterator<E> implements Iterator<E> {
-  final Iterator<Set<E>> _iterator;
-  Iterator<E>? _innerIterator;
+  /// Creates an instance of [OrderedSet] using the [PriorityOrderedSet]
+  /// implementation and the provided [priority] mapping function.
+  static PriorityOrderedSet<K, E> mapping<K extends Comparable<K>, E>(
+    K Function(E a) priority,
+  ) {
+    return PriorityOrderedSet(priority);
+  }
 
-  _OrderedSetIterator(OrderedSet<E> orderedSet)
-      : _iterator = orderedSet._backingSet.iterator;
+  /// Creates an instance of [OrderedSet] for items that are already
+  /// [Comparable] using the [PriorityOrderedSet] implementation.
+  /// Use this for classes that implement [Comparable] of a different class.
+  /// Equivalent to `mapping<K, E>((a) => a)`.
+  static PriorityOrderedSet<K, E>
+      comparable<K extends Comparable<K>, E extends K>() {
+    return mapping<K, E>((a) => a);
+  }
 
-  @override
-  E get current => _innerIterator!.current;
+  /// Creates an instance of [OrderedSet] for items that are already
+  /// [Comparable] of themselves, using the [PriorityOrderedSet] implementation.
+  /// Use this for classes that implement [Comparable] of themselves.
+  /// Equivalent to `mapping<K, K>((a) => a)`.
+  static PriorityOrderedSet<E, E> simple<E extends Comparable<E>>() {
+    return comparable<E, E>();
+  }
 
-  @pragma('vm:prefer-inline')
-  @pragma('wasm:prefer-inline')
-  @override
-  bool moveNext() {
-    if (_innerIterator?.moveNext() != true) {
-      final result = _iterator.moveNext();
-
-      if (!result) {
-        return false;
-      }
-
-      _innerIterator = _iterator.current.iterator;
-      return _innerIterator!.moveNext();
-    }
-    return true;
+  /// Creates an instance of [OrderedSet] using the [QueryableOrderedSet]
+  /// by wrapping the provided [backingSet].
+  static QueryableOrderedSet<E> queryable<E>(
+    OrderedSet<E> backingSet, {
+    bool strictMode = true,
+  }) {
+    return QueryableOrderedSet<E>(backingSet, strictMode: strictMode);
   }
 }

--- a/lib/ordered_set_iterator.dart
+++ b/lib/ordered_set_iterator.dart
@@ -1,0 +1,31 @@
+import 'package:ordered_set/ordered_set.dart';
+
+/// An iterator that flattens and iterates an [OrderedSet] without
+/// any additional overhead.
+class OrderedSetIterator<E> implements Iterator<E> {
+  final Iterator<Set<E>> _iterator;
+  Iterator<E>? _innerIterator;
+
+  OrderedSetIterator.from(this._iterator);
+
+  @override
+  E get current => _innerIterator!.current;
+
+  @pragma('vm:prefer-inline')
+  @pragma('wasm:prefer-inline')
+  @override
+  bool moveNext() {
+    if (_innerIterator?.moveNext() != true) {
+      final result = _iterator.moveNext();
+
+      if (!result) {
+        return false;
+      }
+
+      _innerIterator = _iterator.current.iterator;
+      _innerIterator!.moveNext();
+      return true;
+    }
+    return true;
+  }
+}

--- a/lib/priority_ordered_set.dart
+++ b/lib/priority_ordered_set.dart
@@ -1,0 +1,55 @@
+import 'dart:collection';
+
+import 'package:ordered_set/comparing_ordered_set.dart';
+import 'package:ordered_set/ordered_set.dart';
+
+/// A simple implementation of [OrderedSet] that uses a [SplayTreeSet] as the
+/// backing store.
+///
+/// This wraps the [ComparingOrderedSet] implementation, but uses a cache for
+/// the priority so ordering only changes when rebalance is called.
+/// However this means that you cannot remove elements by reference if their
+/// priority has changed since last rebalance.
+/// For an alternative implementation, use [PriorityOrderedSet].
+class PriorityOrderedSet<K extends Comparable<K>, E> extends OrderedSet<E> {
+  final K Function(E a) _priorityFunction;
+  final OrderedSet<(K, E)> _backingSet = ComparingOrderedSet<(K, E)>(
+    (a, b) => a.$1.compareTo(b.$1),
+  );
+
+  PriorityOrderedSet(this._priorityFunction);
+
+  @override
+  int get length => _backingSet.length;
+
+  @override
+  Iterator<E> get iterator => _backingSet.map((e) => e.$2).iterator;
+
+  @override
+  bool add(E e) {
+    return _backingSet.add((_priorityFunction(e), e));
+  }
+
+  @override
+  void clear() => _backingSet.clear();
+
+  @override
+  void rebalanceAll() {
+    final elements = toList(growable: false);
+    clear();
+    addAll(elements); // addAll will re-prioritize the elements
+  }
+
+  @override
+  void rebalanceWhere(bool Function(E element) test) {
+    final elements =
+        _backingSet.removeWhere((e) => test(e.$2)).map((e) => e.$2);
+    addAll(elements); // addAll will re-prioritize the elements
+  }
+
+  @override
+  bool remove(E e) => _backingSet.remove((_priorityFunction(e), e));
+
+  @override
+  Iterable<E> reversed() => _backingSet.reversed().map((e) => e.$2);
+}

--- a/lib/priority_ordered_set.dart
+++ b/lib/priority_ordered_set.dart
@@ -3,53 +3,134 @@ import 'dart:collection';
 import 'package:ordered_set/comparing_ordered_set.dart';
 import 'package:ordered_set/ordered_set.dart';
 
-/// A simple implementation of [OrderedSet] that uses a [SplayTreeSet] as the
+/// A simple implementation of [OrderedSet] that uses a [SplayTreeMap] as the
 /// backing store.
 ///
-/// This wraps the [ComparingOrderedSet] implementation, but uses a cache for
-/// the priority so ordering only changes when rebalance is called.
-/// However this means that you cannot remove elements by reference if their
-/// priority has changed since last rebalance.
-/// For an alternative implementation, use [PriorityOrderedSet].
+/// This allows it to keep a cache of elements priorities, so they can be used
+/// changed without rebalancing.
+/// For an alternative implementation, use [ComparingOrderedSet].
 class PriorityOrderedSet<K extends Comparable<K>, E> extends OrderedSet<E> {
   final K Function(E a) _priorityFunction;
-  final OrderedSet<(K, E)> _backingSet = ComparingOrderedSet<(K, E)>(
-    (a, b) => a.$1.compareTo(b.$1),
-  );
+  late SplayTreeMap<K, Set<E>> _backingSet;
+  late int _length;
 
-  PriorityOrderedSet(this._priorityFunction);
+  bool _validReverseCache = true;
+  Iterable<E> _reverseCache = const Iterable.empty();
 
-  @override
-  int get length => _backingSet.length;
-
-  @override
-  Iterator<E> get iterator => _backingSet.map((e) => e.$2).iterator;
-
-  @override
-  bool add(E e) {
-    return _backingSet.add((_priorityFunction(e), e));
+  PriorityOrderedSet(this._priorityFunction) {
+    _backingSet = SplayTreeMap((K k1, K k2) {
+      return k1.compareTo(k2);
+    });
+    _length = 0;
   }
 
   @override
-  void clear() => _backingSet.clear();
+  int get length => _length;
+
+  @override
+  Iterator<E> get iterator {
+    return _PriorityOrderedSetIterator<K, E>(this);
+  }
+
+  @override
+  Iterable<E> reversed() {
+    if (!_validReverseCache) {
+      _reverseCache = toList(growable: false).reversed;
+    }
+    return _reverseCache;
+  }
+
+  @override
+  bool add(E e) {
+    final elementPriority = _priorityFunction(e);
+    final innerSet = _backingSet.putIfAbsent(elementPriority, () => <E>{});
+    final added = innerSet.add(e);
+    if (added) {
+      _length++;
+      _validReverseCache = false;
+    }
+    return added;
+  }
 
   @override
   void rebalanceAll() {
     final elements = toList(growable: false);
     clear();
-    addAll(elements); // addAll will re-prioritize the elements
+    addAll(elements);
   }
 
   @override
   void rebalanceWhere(bool Function(E element) test) {
-    final elements =
-        _backingSet.removeWhere((e) => test(e.$2)).map((e) => e.$2);
-    addAll(elements); // addAll will re-prioritize the elements
+    final elements = removeWhere(test);
+    addAll(elements);
   }
 
   @override
-  bool remove(E e) => _backingSet.remove((_priorityFunction(e), e));
+  bool remove(E e) {
+    K? key = _priorityFunction(e);
+    var bucket = _backingSet[key];
+    if (bucket == null || !bucket.contains(e)) {
+      // We need a fallback in case [e] has changed and it's no longer found by
+      // lookup. Note: changing priorities will leave the splay set on an
+      // unknown state; other methods might not work. You must call rebalance to
+      // make sure the state is consistent. This is just for convenient usage by
+      // the rebalancing method itself.
+      final possibleBuckets = _backingSet.entries.where((bucket) {
+        return bucket.value.any((element) => identical(element, e));
+      });
+      final possibleBucket = possibleBuckets.firstOrNull;
+      bucket = possibleBucket?.value;
+      key = possibleBucket?.key;
+    }
+    if (bucket == null || key == null) {
+      return false;
+    }
+    final result = bucket.remove(e);
+    if (result) {
+      _length--;
+      // If the removal resulted in an empty bucket, remove the bucket as well.
+      if (bucket.isEmpty) {
+        _backingSet.remove(key);
+      }
+      _validReverseCache = false;
+    }
+    return result;
+  }
 
   @override
-  Iterable<E> reversed() => _backingSet.reversed().map((e) => e.$2);
+  void clear() {
+    _validReverseCache = false;
+    _backingSet.clear();
+    _length = 0;
+  }
+}
+
+class _PriorityOrderedSetIterator<K extends Comparable<K>, E>
+    implements Iterator<E> {
+  final Iterator<Set<E>> _iterator;
+  Iterator<E>? _innerIterator;
+
+  _PriorityOrderedSetIterator(PriorityOrderedSet<K, E> orderedSet)
+      : _iterator = orderedSet._backingSet.values.iterator;
+
+  @override
+  E get current => _innerIterator!.current;
+
+  @pragma('vm:prefer-inline')
+  @pragma('wasm:prefer-inline')
+  @override
+  bool moveNext() {
+    if (_innerIterator?.moveNext() != true) {
+      final result = _iterator.moveNext();
+
+      if (!result) {
+        return false;
+      }
+
+      _innerIterator = _iterator.current.iterator;
+      _innerIterator!.moveNext();
+      return true;
+    }
+    return true;
+  }
 }

--- a/lib/queryable_ordered_set.dart
+++ b/lib/queryable_ordered_set.dart
@@ -1,15 +1,5 @@
 import 'package:ordered_set/ordered_set.dart';
 
-class _CacheEntry<C, T> {
-  final List<C> data;
-
-  _CacheEntry({required this.data});
-
-  bool check(T t) {
-    return t is C;
-  }
-}
-
 /// This is an implementation of [OrderedSet] that allows you to more
 /// efficiently [query] the list.
 ///
@@ -150,4 +140,14 @@ class QueryableOrderedSet<E> extends OrderedSet<E> {
   }
 
   List<C> _filter<C extends E>() => whereType<C>().toList();
+}
+
+class _CacheEntry<C, T> {
+  final List<C> data;
+
+  _CacheEntry({required this.data});
+
+  bool check(T t) {
+    return t is C;
+  }
 }

--- a/lib/queryable_ordered_set.dart
+++ b/lib/queryable_ordered_set.dart
@@ -31,18 +31,19 @@ class _CacheEntry<C, T> {
 ///
 /// Note that you can change [strictMode] to allow for querying for unregistered
 /// types; if you do so, the registration cost is payed on the first query.
-class QueryableOrderedSet<T> extends OrderedSet<T> {
+class QueryableOrderedSet<E> extends OrderedSet<E> {
   /// Controls whether running an unregistered query throws an error or
   /// performs just-in-time filtering.
   final bool strictMode;
-  final Map<Type, _CacheEntry<T, T>> _cache = {};
+  final Map<Type, _CacheEntry<E, E>> _cache = {};
+  final OrderedSet<E> _backingSet;
 
-  QueryableOrderedSet({
-    int Function(T e1, T e2)? comparator,
+  QueryableOrderedSet(
+    this._backingSet, {
     this.strictMode = true,
-  }) : super(comparator);
+  });
 
-  /// Adds a new cache for a subtype [C] of [T], allowing you to call [query].
+  /// Adds a new cache for a subtype [C] of [E], allowing you to call [query].
   /// If the cache already exists this operation is a no-op.
   ///
   /// If the set is not empty, the current elements will be re-sorted.
@@ -50,11 +51,11 @@ class QueryableOrderedSet<T> extends OrderedSet<T> {
   /// It is recommended to [register] all desired types at the beginning of
   /// your application to avoid recomputing the existing elements upon
   /// registration.
-  void register<C extends T>() {
+  void register<C extends E>() {
     if (isRegistered<C>()) {
       return;
     }
-    _cache[C] = _CacheEntry<C, T>(
+    _cache[C] = _CacheEntry<C, E>(
       data: _filter<C>(),
     );
   }
@@ -70,7 +71,7 @@ class QueryableOrderedSet<T> extends OrderedSet<T> {
   ///
   /// Note: you *must* call [register] for every type [C] you desire to use
   /// before calling this, or set [strictMode] to false.
-  Iterable<C> query<C extends T>() {
+  Iterable<C> query<C extends E>() {
     final result = _cache[C];
     if (result == null) {
       if (strictMode) {
@@ -105,8 +106,27 @@ class QueryableOrderedSet<T> extends OrderedSet<T> {
   bool isRegistered<C>() => _cache.containsKey(C);
 
   @override
-  bool add(T t) {
-    if (super.add(t)) {
+  int get length => _backingSet.length;
+
+  @override
+  Iterator<E> get iterator => _backingSet.iterator;
+
+  @override
+  Iterable<E> reversed() => _backingSet.reversed();
+
+  @override
+  void rebalanceAll() {
+    _backingSet.rebalanceAll();
+  }
+
+  @override
+  void rebalanceWhere(bool Function(E element) test) {
+    _backingSet.rebalanceWhere(test);
+  }
+
+  @override
+  bool add(E t) {
+    if (_backingSet.add(t)) {
       _cache.forEach((key, value) {
         if (value.check(t)) {
           value.data.add(t);
@@ -118,16 +138,16 @@ class QueryableOrderedSet<T> extends OrderedSet<T> {
   }
 
   @override
-  bool remove(T e) {
+  bool remove(E e) {
     _cache.values.forEach((v) => v.data.remove(e));
-    return super.remove(e);
+    return _backingSet.remove(e);
   }
 
   @override
   void clear() {
     _cache.values.forEach((v) => v.data.clear());
-    super.clear();
+    _backingSet.clear();
   }
 
-  List<C> _filter<C extends T>() => whereType<C>().toList();
+  List<C> _filter<C extends E>() => whereType<C>().toList();
 }

--- a/test/comparing_ordered_set_test.dart
+++ b/test/comparing_ordered_set_test.dart
@@ -1,0 +1,424 @@
+import 'package:ordered_set/comparing.dart';
+import 'package:ordered_set/ordered_set.dart';
+import 'package:test/test.dart';
+
+import 'comparable_object.dart';
+
+void main() {
+  group('ComparingOrderedSet', () {
+    group('#removeWhere', () {
+      test('remove single element', () {
+        final a = OrderedSet.comparing<int>();
+        expect(a.addAll([7, 4, 3, 1, 2, 6, 5]), 7);
+        expect(a.length, 7);
+        expect(a.removeWhere((e) => e == 3).length, 1);
+        expect(a.length, 6);
+        expect(a.toList().join(), '124567');
+      });
+
+      test('remove with property', () {
+        final a = OrderedSet.comparing<int>();
+        expect(a.addAll([7, 4, 3, 1, 2, 6, 5]), 7);
+        expect(a.removeWhere((e) => e.isOdd).length, 4);
+        expect(a.length, 3);
+        expect(a.toList().join(), '246');
+      });
+
+      test('remove when element has changed', () {
+        final a = OrderedSet.comparing<ComparableObject>();
+
+        final e1 = ComparableObject(1, 'e1');
+        final e2 = ComparableObject(1, 'e2');
+        final e3 = ComparableObject(2, 'e3');
+        final e4 = ComparableObject(2, 'e4');
+
+        a.addAll([e1, e2, e3, e4]);
+        e1.priority = 2;
+        // no rebalance! note that this is a broken state until rebalance is
+        // called.
+        expect(a.remove(e1), isTrue);
+        expect(a.toList().join(), 'e2e3e4');
+      });
+
+      test('remove returns the removed elements', () {
+        final a = OrderedSet.comparing<int>();
+        a.addAll([7, 4, 3, 1, 2, 6, 5]);
+        final removed = a.removeWhere((e) => e <= 2);
+        expect(removed.length, 2);
+        expect(removed.toList().join(), '12');
+      });
+
+      test('remove from same group and different groups', () {
+        final a = OrderedSet.comparing<ComparableObject>();
+        expect(a.add(ComparableObject(0, 'a1')), isTrue);
+        expect(a.add(ComparableObject(0, 'a2')), isTrue);
+        expect(a.add(ComparableObject(0, 'b1')), isTrue);
+        expect(a.add(ComparableObject(1, 'a3')), isTrue);
+        expect(a.add(ComparableObject(1, 'b2')), isTrue);
+        expect(a.add(ComparableObject(1, 'b3')), isTrue);
+        expect(a.add(ComparableObject(2, 'a4')), isTrue);
+        expect(a.add(ComparableObject(2, 'b4')), isTrue);
+        expect(a.removeWhere((e) => e.name.startsWith('a')).length, 4);
+        expect(a.length, 4);
+        expect(a.toList().join(), 'b1b2b3b4');
+      });
+
+      test('remove all', () {
+        final a = OrderedSet.comparing<ComparableObject>();
+        expect(a.add(ComparableObject(0, 'a1')), isTrue);
+        expect(a.add(ComparableObject(0, 'a2')), isTrue);
+        expect(a.add(ComparableObject(0, 'b1')), isTrue);
+        expect(a.add(ComparableObject(1, 'a3')), isTrue);
+        expect(a.add(ComparableObject(1, 'b2')), isTrue);
+        expect(a.add(ComparableObject(1, 'b3')), isTrue);
+        expect(a.add(ComparableObject(2, 'a4')), isTrue);
+        expect(a.add(ComparableObject(2, 'b4')), isTrue);
+        expect(a.removeWhere((e) => true).length, 8);
+        expect(a.length, 0);
+        expect(a.toList().join(), '');
+      });
+    });
+
+    group('#removeAt', () {
+      test('removes the element at index', () {
+        final a = OrderedSet.comparing<int>();
+        a.addAll([1, 2, 3, 4, 5, 6]);
+        expect(a.length, 6);
+        expect(a.removeAt(3), isTrue);
+        expect(a.length, 5);
+        expect(a.contains(4), isFalse);
+      });
+
+      test('does not remove non-existing index', () {
+        final a = OrderedSet.comparing<int>();
+        a.addAll([1, 2, 3, 4, 5, 6]);
+        expect(a.length, 6);
+        expect(() => a.removeAt(7), throwsRangeError);
+        expect(a.length, 6);
+      });
+    });
+
+    group('#clear', () {
+      test('removes all and updates length', () {
+        final a = OrderedSet.comparing<int>();
+        expect(a.addAll([1, 2, 3, 4, 5, 6]), 6);
+        a.clear();
+        expect(a.length, 0);
+        expect(a.toList().length, 0);
+      });
+    });
+
+    group('#addAll', () {
+      test('maintains order', () {
+        final a = OrderedSet.comparing<int>();
+        expect(a.length, 0);
+        expect(a.addAll([7, 4, 3, 1, 2, 6, 5]), 7);
+        expect(a.length, 7);
+        expect(a.toList().join(), '1234567');
+      });
+
+      test('with repeated priority elements', () {
+        final a = OrderedSet.comparing<int>((a, b) => (a % 2) - (b % 2));
+        expect(a.addAll([7, 4, 3, 1, 2, 6, 5]), 7);
+        expect(a.length, 7);
+        expect(a.toList().join(), '4267315');
+
+        final b = OrderedSet.comparing<int>((a, b) => 0);
+        expect(b.addAll([7, 4, 3, 1, 2, 6, 5]), 7);
+        expect(a.length, 7);
+        expect(b.toList().join(), '7431265');
+      });
+
+      test('with identical elements', () {
+        final a = OrderedSet.comparing<int>();
+        expect(a.addAll([4, 3, 3, 2, 2, 2, 1]), 4);
+        expect(a.length, 4);
+        expect(a.toList().join(), '1234');
+      });
+
+      test('elements with same priorities', () {
+        final a = OrderedSet.comparing<ComparableObject>();
+
+        final e1 = ComparableObject(1, 'e1');
+        final e2 = ComparableObject(1, 'e2');
+        final e3 = ComparableObject(2, 'e3');
+        final e4 = ComparableObject(2, 'e4');
+        a.addAll([e1, e3, e2, e4]);
+
+        expect(a.toList().join(), 'e1e2e3e4');
+        a.remove(e2);
+        expect(a.toList().join(), 'e1e3e4');
+        a.add(e2);
+        expect(a.toList().join(), 'e1e2e3e4');
+      });
+
+      test('duplicated item is discarded', () {
+        final a = OrderedSet.comparing<int>();
+        a.add(2);
+        a.add(1);
+        a.add(2);
+        expect(a.length, 2);
+        expect(a.toList().join(), '12');
+      });
+    });
+
+    group('#length', () {
+      test('keeps track of length when adding', () {
+        final a = OrderedSet.comparing<int>();
+        expect(a.add(1), isTrue);
+        expect(a.length, 1);
+        expect(a.add(2), isTrue);
+        expect(a.length, 2);
+        expect(a.add(3), isTrue);
+        expect(a.length, 3);
+      });
+
+      test('keeps track of length when removing', () {
+        final a = OrderedSet.comparing<int>((a, b) => 0); // no priority
+        expect(a.addAll([1, 2, 3, 4]), 4);
+        expect(a.length, 4);
+
+        expect(a.remove(1), isTrue);
+        expect(a.length, 3);
+        expect(a.remove(1), isFalse);
+        expect(a.length, 3);
+
+        expect(a.remove(5), isFalse); // never been there
+        expect(a.length, 3);
+
+        expect(a.remove(2), isTrue);
+        expect(a.remove(3), isTrue);
+        expect(a.length, 1);
+
+        expect(a.remove(4), isTrue);
+        expect(a.length, 0);
+        expect(a.remove(4), isFalse);
+      });
+    });
+
+    group('#add/#remove', () {
+      test('no comparator test with int', () {
+        final a = OrderedSet.comparing<int>();
+        expect(a.add(2), isTrue);
+        expect(a.add(1), isTrue);
+        expect(a.toList(), [1, 2]);
+      });
+
+      test('no comparator test with string', () {
+        final a = OrderedSet.comparing<String>();
+        expect(a.add('aab'), isTrue);
+        expect(a.add('cab'), isTrue);
+        expect(a.add('bab'), isTrue);
+        expect(a.toList(), ['aab', 'bab', 'cab']);
+      });
+
+      test('no comparator test with comparable', () {
+        final a = OrderedSet.comparing<ComparableObject>();
+        expect(a.add(ComparableObject(12, 'Klaus')), isTrue);
+        expect(a.add(ComparableObject(1, 'Sunny')), isTrue);
+        expect(a.add(ComparableObject(14, 'Violet')), isTrue);
+        final expected = ['Sunny', 'Klaus', 'Violet'];
+        expect(a.toList().map((e) => e.name).toList(), expected);
+      });
+
+      test('test with custom comparator', () {
+        final a = OrderedSet.comparing<ComparableObject>(
+          (a, b) => a.name.compareTo(b.name),
+        );
+        expect(a.add(ComparableObject(1, 'Sunny')), isTrue);
+        expect(a.add(ComparableObject(12, 'Klaus')), isTrue);
+        expect(a.add(ComparableObject(14, 'Violet')), isTrue);
+        final expected = ['Klaus', 'Sunny', 'Violet'];
+        expect(a.toList().map((e) => e.name).toList(), expected);
+      });
+
+      test(
+        'test items with repeated comparables, maintain insertion order',
+        () {
+          final a = OrderedSet.comparing<int>((a, b) => (a % 2) - (b % 2));
+          for (var i = 0; i < 10; i++) {
+            expect(a.add(i), isTrue);
+          }
+          expect(a.toList(), [0, 2, 4, 6, 8, 1, 3, 5, 7, 9]);
+        },
+      );
+
+      test('test items with actual duplicated items', () {
+        final a = OrderedSet.comparing<int>();
+        expect(a.add(1), isTrue);
+        expect(a.add(1), isFalse);
+        expect(a.toList(), [1]);
+      });
+
+      test('test remove items', () {
+        final a = OrderedSet.comparing<int>();
+        expect(a.add(1), isTrue);
+        expect(a.add(2), isTrue);
+        expect(a.add(0), isTrue);
+        expect(a.remove(1), isTrue);
+        expect(a.remove(3), isFalse);
+        expect(a.toList(), [0, 2]);
+      });
+
+      test('test remove with duplicates', () {
+        final a = OrderedSet.comparing<int>();
+        expect(a.add(0), isTrue);
+        expect(a.add(1), isTrue);
+        expect(a.add(1), isFalse);
+        expect(a.add(2), isTrue);
+        expect(a.toList(), [0, 1, 2]);
+        expect(a.remove(1), isTrue);
+        expect(a.toList(), [0, 2]);
+        expect(a.remove(1), isFalse);
+        expect(a.toList(), [0, 2]);
+      });
+
+      test('with custom comparator, repeated items and removal', () {
+        final a = OrderedSet.comparing<ComparableObject>(
+          (a, b) => -a.priority.compareTo(b.priority),
+        );
+        final a1 = ComparableObject(2, '1');
+        final a2 = ComparableObject(2, '2');
+        final a3 = ComparableObject(1, '3');
+        final a4 = ComparableObject(1, '4');
+        final a5 = ComparableObject(1, '5');
+        final a6 = ComparableObject(0, '6');
+        expect(a.add(a6), isTrue);
+        expect(a.add(a3), isTrue);
+        expect(a.add(a4), isTrue);
+        expect(a.add(a5), isTrue);
+        expect(a.add(a1), isTrue);
+        expect(a.add(a2), isTrue);
+        expect(a.toList().join(), '123456');
+
+        expect(a.remove(a4), isTrue);
+        expect(a.toList().join(), '12356');
+        expect(a.remove(a4), isFalse);
+        expect(a.toList().join(), '12356');
+
+        expect(a.remove(ComparableObject(1, '5')), isFalse);
+        expect(a.toList().join(), '12356');
+        expect(a.remove(a5), isTrue);
+        expect(a.toList().join(), '1236');
+
+        expect(a.add(ComparableObject(10, '*')), isTrue);
+        expect(a.toList().join(), '*1236');
+
+        expect(a.remove(a1), isTrue);
+        expect(a.remove(a6), isTrue);
+        expect(a.toList().join(), '*23');
+
+        expect(a.add(ComparableObject(-10, '*')), isTrue);
+        expect(a.toList().join(), '*23*');
+        expect(a.remove(a2), isTrue);
+        expect(a.toList().join(), '*3*');
+        expect(a.remove(a2), isFalse);
+        expect(a.remove(a2), isFalse);
+        expect(a.toList().join(), '*3*');
+        expect(a.remove(a3), isTrue);
+        expect(a.toList().join(), '**');
+      });
+
+      test('removeAll', () {
+        final orderedSet = OrderedSet.comparing<ComparableObject>(
+          Comparing.on((e) => e.priority),
+        );
+
+        final a = ComparableObject(0, 'a');
+        final b = ComparableObject(1, 'b');
+        final c = ComparableObject(2, 'c');
+        final d = ComparableObject(3, 'd');
+
+        orderedSet.addAll([d, b, a, c]);
+        expect(orderedSet.removeAll([c, a]).join(), 'ca');
+        expect(orderedSet.toList().join(), 'bd');
+        orderedSet.addAll([d, b, a, c]);
+        expect(orderedSet.removeAll([d, b]).join(), 'db');
+        expect(orderedSet.toList().join(), 'ac');
+      });
+
+      test('sorts after remove', () {
+        final orderedSet = OrderedSet.comparing<int>();
+        orderedSet.addAll([1, 3, 4]);
+        expect(orderedSet.toList().join(), '134');
+        expect(orderedSet.remove(4), true);
+        expect(orderedSet.toList().join(), '13');
+        expect(orderedSet.add(2), true);
+        expect(orderedSet.toList().join(), '123');
+      });
+
+      test('correct order after remove', () {
+        final orderedSet = OrderedSet.comparing<int>();
+        orderedSet.add(10);
+        orderedSet.add(9);
+        orderedSet.remove(10);
+        orderedSet.add(11);
+        orderedSet.add(8);
+        expect(orderedSet.toList(), [8, 9, 11]);
+      });
+    });
+
+    group('rebalancing', () {
+      test('rebalanceWhere and rebalanceAll', () {
+        final orderedSet = OrderedSet.comparing<ComparableObject>(
+          Comparing.on((e) => e.priority),
+        );
+
+        final a = ComparableObject(0, 'a');
+        final b = ComparableObject(1, 'b');
+        final c = ComparableObject(2, 'c');
+        final d = ComparableObject(3, 'd');
+
+        orderedSet.addAll([d, b, a, c]);
+        expect(orderedSet.toList().join(), 'abcd');
+
+        a.priority = 4;
+        expect(orderedSet.toList().join(), 'abcd');
+        orderedSet.rebalanceWhere((e) => identical(e, a));
+        expect(orderedSet.toList().join(), 'bcda');
+
+        b.priority = 5;
+        c.priority = -1;
+        expect(orderedSet.toList().join(), 'bcda');
+        orderedSet.rebalanceAll();
+        expect(orderedSet.toList().join(), 'cdab');
+      });
+    });
+
+    group('reversed', () {
+      test('reversed properly invalidates cache', () {
+        final orderedSet = OrderedSet.comparing<ComparableObject>(
+          Comparing.on((e) => e.priority),
+        );
+
+        final a = ComparableObject(0, 'a');
+        final b = ComparableObject(1, 'b');
+        final c = ComparableObject(2, 'c');
+        final d = ComparableObject(3, 'd');
+
+        orderedSet.addAll([d, b, a, c]);
+        expect(orderedSet.reversed().join(), 'dcba');
+
+        a.priority = 4;
+        expect(orderedSet.reversed().join(), 'dcba');
+        orderedSet.rebalanceWhere((e) => identical(e, a));
+        expect(orderedSet.reversed().join(), 'adcb');
+
+        b.priority = 5;
+        c.priority = -1;
+        expect(orderedSet.reversed().join(), 'adcb');
+        orderedSet.rebalanceAll();
+        expect(orderedSet.reversed().join(), 'badc');
+
+        orderedSet.remove(d);
+        expect(orderedSet.reversed().join(), 'bac');
+        orderedSet.add(d);
+        expect(orderedSet.reversed().join(), 'badc');
+        orderedSet.removeAll([a, b]);
+        expect(orderedSet.reversed().join(), 'dc');
+        orderedSet.addAll([a, b]);
+        expect(orderedSet.reversed().join(), 'badc');
+      });
+    });
+  });
+}

--- a/test/comparing_test.dart
+++ b/test/comparing_test.dart
@@ -1,5 +1,5 @@
 import 'package:ordered_set/comparing.dart';
-import 'package:ordered_set/ordered_set.dart';
+import 'package:ordered_set/comparing_ordered_set.dart';
 import 'package:test/test.dart';
 
 import 'comparable_object.dart';
@@ -30,7 +30,9 @@ void main() {
         ]);
       });
       test('using complex object', () {
-        final set = OrderedSet<ComparableObject>(Comparing.on((o) => o.name));
+        final set = ComparingOrderedSet<ComparableObject>(
+          Comparing.on((o) => o.name),
+        );
         set.add(ComparableObject(0, 'd'));
         set.add(ComparableObject(1, 'b'));
         set.add(ComparableObject(2, 'a'));
@@ -53,7 +55,7 @@ void main() {
         final c = Comparing.reverse<ComparableObject>(
           Comparing.on((t) => t.name),
         );
-        final set = OrderedSet(c);
+        final set = ComparingOrderedSet(c);
         set.add(ComparableObject(0, 'd'));
         set.add(ComparableObject(1, 'b'));
         set.add(ComparableObject(2, 'a'));
@@ -68,7 +70,7 @@ void main() {
           (ComparableObject t) => t.priority,
           (ComparableObject t) => t.name,
         ]);
-        final set = OrderedSet(c);
+        final set = ComparingOrderedSet(c);
         set.add(ComparableObject(1, 'b'));
         set.add(ComparableObject(0, 'b'));
         set.add(ComparableObject(3, 'a'));

--- a/test/priority_ordered_set_test.dart
+++ b/test/priority_ordered_set_test.dart
@@ -1,14 +1,13 @@
-import 'package:ordered_set/comparing.dart';
 import 'package:ordered_set/ordered_set.dart';
 import 'package:test/test.dart';
 
 import 'comparable_object.dart';
 
 void main() {
-  group('OrderedSet', () {
+  group('PriorityOrderedSet', () {
     group('#removeWhere', () {
       test('remove single element', () {
-        final a = OrderedSet<int>();
+        final a = OrderedSet.comparable<num, int>();
         expect(a.addAll([7, 4, 3, 1, 2, 6, 5]), 7);
         expect(a.length, 7);
         expect(a.removeWhere((e) => e == 3).length, 1);
@@ -17,7 +16,7 @@ void main() {
       });
 
       test('remove with property', () {
-        final a = OrderedSet<int>();
+        final a = OrderedSet.comparable<num, int>();
         expect(a.addAll([7, 4, 3, 1, 2, 6, 5]), 7);
         expect(a.removeWhere((e) => e.isOdd).length, 4);
         expect(a.length, 3);
@@ -25,7 +24,7 @@ void main() {
       });
 
       test('remove when element has changed', () {
-        final a = OrderedSet<ComparableObject>();
+        final a = OrderedSet.mapping<num, ComparableObject>((e) => e.priority);
 
         final e1 = ComparableObject(1, 'e1');
         final e2 = ComparableObject(1, 'e2');
@@ -36,12 +35,19 @@ void main() {
         e1.priority = 2;
         // no rebalance! note that this is a broken state until rebalance is
         // called.
+
+        // cannot find because of the priority diff
+        // this is the key difference of PriorityOrderedSet
+        expect(a.remove(e1), isFalse);
+
+        a.rebalanceWhere((e) => e == e1);
         expect(a.remove(e1), isTrue);
+
         expect(a.toList().join(), 'e2e3e4');
       });
 
       test('remove returns the removed elements', () {
-        final a = OrderedSet<int>();
+        final a = OrderedSet.comparable<num, int>();
         a.addAll([7, 4, 3, 1, 2, 6, 5]);
         final removed = a.removeWhere((e) => e <= 2);
         expect(removed.length, 2);
@@ -49,7 +55,7 @@ void main() {
       });
 
       test('remove from same group and different groups', () {
-        final a = OrderedSet<ComparableObject>();
+        final a = OrderedSet.mapping<num, ComparableObject>((e) => e.priority);
         expect(a.add(ComparableObject(0, 'a1')), isTrue);
         expect(a.add(ComparableObject(0, 'a2')), isTrue);
         expect(a.add(ComparableObject(0, 'b1')), isTrue);
@@ -64,7 +70,7 @@ void main() {
       });
 
       test('remove all', () {
-        final a = OrderedSet<ComparableObject>();
+        final a = OrderedSet.mapping<num, ComparableObject>((e) => e.priority);
         expect(a.add(ComparableObject(0, 'a1')), isTrue);
         expect(a.add(ComparableObject(0, 'a2')), isTrue);
         expect(a.add(ComparableObject(0, 'b1')), isTrue);
@@ -81,7 +87,7 @@ void main() {
 
     group('#removeAt', () {
       test('removes the element at index', () {
-        final a = OrderedSet<int>();
+        final a = OrderedSet.comparable<num, int>();
         a.addAll([1, 2, 3, 4, 5, 6]);
         expect(a.length, 6);
         expect(a.removeAt(3), isTrue);
@@ -90,7 +96,7 @@ void main() {
       });
 
       test('does not remove non-existing index', () {
-        final a = OrderedSet<int>();
+        final a = OrderedSet.comparable<num, int>();
         a.addAll([1, 2, 3, 4, 5, 6]);
         expect(a.length, 6);
         expect(() => a.removeAt(7), throwsRangeError);
@@ -100,7 +106,7 @@ void main() {
 
     group('#clear', () {
       test('removes all and updates length', () {
-        final a = OrderedSet<int>();
+        final a = OrderedSet.comparable<num, int>();
         expect(a.addAll([1, 2, 3, 4, 5, 6]), 6);
         a.clear();
         expect(a.length, 0);
@@ -110,7 +116,7 @@ void main() {
 
     group('#addAll', () {
       test('maintains order', () {
-        final a = OrderedSet<int>();
+        final a = OrderedSet.comparable<num, int>();
         expect(a.length, 0);
         expect(a.addAll([7, 4, 3, 1, 2, 6, 5]), 7);
         expect(a.length, 7);
@@ -118,26 +124,26 @@ void main() {
       });
 
       test('with repeated priority elements', () {
-        final a = OrderedSet<int>((a, b) => (a % 2) - (b % 2));
+        final a = OrderedSet.mapping<num, int>((e) => e % 2);
         expect(a.addAll([7, 4, 3, 1, 2, 6, 5]), 7);
         expect(a.length, 7);
         expect(a.toList().join(), '4267315');
 
-        final b = OrderedSet<int>((a, b) => 0);
+        final b = OrderedSet.mapping<num, int>((e) => 0);
         expect(b.addAll([7, 4, 3, 1, 2, 6, 5]), 7);
         expect(a.length, 7);
         expect(b.toList().join(), '7431265');
       });
 
       test('with identical elements', () {
-        final a = OrderedSet<int>();
+        final a = OrderedSet.comparable<num, int>();
         expect(a.addAll([4, 3, 3, 2, 2, 2, 1]), 4);
         expect(a.length, 4);
         expect(a.toList().join(), '1234');
       });
 
       test('elements with same priorities', () {
-        final a = OrderedSet<ComparableObject>();
+        final a = OrderedSet.mapping<num, ComparableObject>((e) => e.priority);
 
         final e1 = ComparableObject(1, 'e1');
         final e2 = ComparableObject(1, 'e2');
@@ -153,7 +159,7 @@ void main() {
       });
 
       test('duplicated item is discarded', () {
-        final a = OrderedSet<int>();
+        final a = OrderedSet.comparable<num, int>();
         a.add(2);
         a.add(1);
         a.add(2);
@@ -164,7 +170,7 @@ void main() {
 
     group('#length', () {
       test('keeps track of length when adding', () {
-        final a = OrderedSet<int>();
+        final a = OrderedSet.comparable<num, int>();
         expect(a.add(1), isTrue);
         expect(a.length, 1);
         expect(a.add(2), isTrue);
@@ -174,7 +180,7 @@ void main() {
       });
 
       test('keeps track of length when removing', () {
-        final a = OrderedSet<int>((a, b) => 0); // no priority
+        final a = OrderedSet.mapping<num, int>((e) => 0); // no priority
         expect(a.addAll([1, 2, 3, 4]), 4);
         expect(a.length, 4);
 
@@ -198,14 +204,14 @@ void main() {
 
     group('#add/#remove', () {
       test('no comparator test with int', () {
-        final a = OrderedSet<int>();
+        final a = OrderedSet.comparable<num, int>();
         expect(a.add(2), isTrue);
         expect(a.add(1), isTrue);
         expect(a.toList(), [1, 2]);
       });
 
       test('no comparator test with string', () {
-        final a = OrderedSet<String>();
+        final a = OrderedSet.simple<String>();
         expect(a.add('aab'), isTrue);
         expect(a.add('cab'), isTrue);
         expect(a.add('bab'), isTrue);
@@ -213,7 +219,7 @@ void main() {
       });
 
       test('no comparator test with comparable', () {
-        final a = OrderedSet<ComparableObject>();
+        final a = OrderedSet.mapping<num, ComparableObject>((e) => e.priority);
         expect(a.add(ComparableObject(12, 'Klaus')), isTrue);
         expect(a.add(ComparableObject(1, 'Sunny')), isTrue);
         expect(a.add(ComparableObject(14, 'Violet')), isTrue);
@@ -222,9 +228,7 @@ void main() {
       });
 
       test('test with custom comparator', () {
-        final a = OrderedSet<ComparableObject>(
-          (a, b) => a.name.compareTo(b.name),
-        );
+        final a = OrderedSet.mapping<String, ComparableObject>((e) => e.name);
         expect(a.add(ComparableObject(1, 'Sunny')), isTrue);
         expect(a.add(ComparableObject(12, 'Klaus')), isTrue);
         expect(a.add(ComparableObject(14, 'Violet')), isTrue);
@@ -235,7 +239,7 @@ void main() {
       test(
         'test items with repeated comparables, maintain insertion order',
         () {
-          final a = OrderedSet<int>((a, b) => (a % 2) - (b % 2));
+          final a = OrderedSet.mapping<num, int>((e) => e % 2);
           for (var i = 0; i < 10; i++) {
             expect(a.add(i), isTrue);
           }
@@ -244,14 +248,14 @@ void main() {
       );
 
       test('test items with actual duplicated items', () {
-        final a = OrderedSet<int>();
+        final a = OrderedSet.comparable<num, int>();
         expect(a.add(1), isTrue);
         expect(a.add(1), isFalse);
         expect(a.toList(), [1]);
       });
 
       test('test remove items', () {
-        final a = OrderedSet<int>();
+        final a = OrderedSet.comparable<num, int>();
         expect(a.add(1), isTrue);
         expect(a.add(2), isTrue);
         expect(a.add(0), isTrue);
@@ -261,7 +265,7 @@ void main() {
       });
 
       test('test remove with duplicates', () {
-        final a = OrderedSet<int>();
+        final a = OrderedSet.comparable<num, int>();
         expect(a.add(0), isTrue);
         expect(a.add(1), isTrue);
         expect(a.add(1), isFalse);
@@ -274,9 +278,7 @@ void main() {
       });
 
       test('with custom comparator, repeated items and removal', () {
-        final a = OrderedSet<ComparableObject>(
-          (a, b) => -a.priority.compareTo(b.priority),
-        );
+        final a = OrderedSet.mapping<num, ComparableObject>((e) => -e.priority);
         final a1 = ComparableObject(2, '1');
         final a2 = ComparableObject(2, '2');
         final a3 = ComparableObject(1, '3');
@@ -320,8 +322,8 @@ void main() {
       });
 
       test('removeAll', () {
-        final orderedSet = OrderedSet<ComparableObject>(
-          Comparing.on((e) => e.priority),
+        final orderedSet = OrderedSet.mapping<num, ComparableObject>(
+          (e) => e.priority,
         );
 
         final a = ComparableObject(0, 'a');
@@ -338,7 +340,7 @@ void main() {
       });
 
       test('sorts after remove', () {
-        final orderedSet = OrderedSet<int>();
+        final orderedSet = OrderedSet.comparable<num, int>();
         orderedSet.addAll([1, 3, 4]);
         expect(orderedSet.toList().join(), '134');
         expect(orderedSet.remove(4), true);
@@ -348,7 +350,7 @@ void main() {
       });
 
       test('correct order after remove', () {
-        final orderedSet = OrderedSet<int>();
+        final orderedSet = OrderedSet.comparable<num, int>();
         orderedSet.add(10);
         orderedSet.add(9);
         orderedSet.remove(10);
@@ -360,8 +362,8 @@ void main() {
 
     group('rebalancing', () {
       test('rebalanceWhere and rebalanceAll', () {
-        final orderedSet = OrderedSet<ComparableObject>(
-          Comparing.on((e) => e.priority),
+        final orderedSet = OrderedSet.mapping<num, ComparableObject>(
+          (e) => e.priority,
         );
 
         final a = ComparableObject(0, 'a');
@@ -387,8 +389,8 @@ void main() {
 
     group('reversed', () {
       test('reversed properly invalidates cache', () {
-        final orderedSet = OrderedSet<ComparableObject>(
-          Comparing.on((e) => e.priority),
+        final orderedSet = OrderedSet.mapping<num, ComparableObject>(
+          (e) => e.priority,
         );
 
         final a = ComparableObject(0, 'a');

--- a/test/queryable_comparable_ordered_set_test.dart
+++ b/test/queryable_comparable_ordered_set_test.dart
@@ -1,4 +1,5 @@
 import 'package:ordered_set/comparing.dart';
+import 'package:ordered_set/ordered_set.dart';
 import 'package:ordered_set/queryable_ordered_set.dart';
 import 'package:test/test.dart';
 
@@ -19,12 +20,10 @@ class Cat extends Mammal {}
 class Cod extends Fish {}
 
 void main() {
-  group('QueryableOrderedSet', () {
+  group('QueryableOrderedSet - Comparable', () {
     group('#add and #query', () {
       test('registration is mandatory on strict mode', () {
-        final orderedSet = QueryableOrderedSet<Animal>(
-          comparator: Comparing.on((e) => e.name),
-        );
+        final orderedSet = _create();
 
         expect(
           () => orderedSet.query<Bird>(),
@@ -32,10 +31,7 @@ void main() {
         );
       });
       test('registration is optional with strict mode = false', () {
-        final orderedSet = QueryableOrderedSet<Animal>(
-          comparator: Comparing.on((e) => e.name),
-          strictMode: false,
-        );
+        final orderedSet = _create(strictMode: false);
         final bird = Bird()..name = 'Louise';
         final cod = Cod()..name = 'Leroy';
         orderedSet.addAll([bird, cod]);
@@ -56,9 +52,7 @@ void main() {
         final dog = Dog()..name = 'Joey';
         final bird = Bird()..name = 'Louise';
 
-        final orderedSet = QueryableOrderedSet<Animal>(
-          comparator: Comparing.on((e) => e.name),
-        );
+        final orderedSet = _create();
         orderedSet.register<Animal>();
         orderedSet.register<Dog>();
         orderedSet.register<Bird>();
@@ -77,9 +71,7 @@ void main() {
         final dog = Dog()..name = 'Joey';
         final bird = Bird()..name = 'Louise';
 
-        final orderedSet = QueryableOrderedSet<Animal>(
-          comparator: Comparing.on((e) => e.name),
-        );
+        final orderedSet = _create();
 
         orderedSet.add(dog);
         orderedSet.add(bird);
@@ -100,20 +92,15 @@ void main() {
         final fish = Fish()..name = 'Abigail';
         final cod = Cod()..name = 'Leroy';
 
-        final orderedSet = QueryableOrderedSet<Animal>(
-          comparator: Comparing.on((e) => e.name),
-        );
+        final orderedSet = _create();
 
         orderedSet.register<Animal>();
-
         orderedSet.add(dog);
 
         orderedSet.register<Mammal>();
-
         orderedSet.add(fish);
 
         orderedSet.register<Dog>();
-
         orderedSet.add(cod);
 
         orderedSet.register<Fish>();
@@ -133,9 +120,7 @@ void main() {
         final dog = Dog()..name = 'Joey';
         final bird = Bird()..name = 'Louise';
 
-        final orderedSet = QueryableOrderedSet<Animal>(
-          comparator: Comparing.on((e) => e.name),
-        );
+        final orderedSet = _create();
         orderedSet.register<Animal>();
         orderedSet.register<Dog>();
         orderedSet.register<Bird>();
@@ -161,9 +146,7 @@ void main() {
         final bird1 = Bird()..name = 'Louise';
         final bird2 = Bird()..name = 'Sally';
 
-        final orderedSet = QueryableOrderedSet<Animal>(
-          comparator: Comparing.on((e) => e.name),
-        );
+        final orderedSet = _create();
         orderedSet.register<Animal>();
         orderedSet.register<Mammal>();
         orderedSet.register<Dog>();
@@ -230,9 +213,7 @@ void main() {
         final bird1 = Bird()..name = 'Louise';
         final bird2 = Bird()..name = 'Sally';
 
-        final orderedSet = QueryableOrderedSet<Animal>(
-          comparator: Comparing.on((e) => e.name),
-        );
+        final orderedSet = _create();
         orderedSet.register<Animal>();
         orderedSet.register<Mammal>();
         orderedSet.register<Dog>();
@@ -252,9 +233,7 @@ void main() {
         expect(orderedSet.toList(), isEmpty);
       });
       test('#isRegistered', () {
-        final orderedSet = QueryableOrderedSet<Animal>(
-          comparator: Comparing.on((e) => e.name),
-        );
+        final orderedSet = _create();
         // No caches should be registered on a clean set
         expect(orderedSet.isRegistered<Animal>(), isFalse);
         expect(orderedSet.isRegistered<Mammal>(), isFalse);
@@ -282,9 +261,7 @@ void main() {
         final dog = Dog()..name = 'Joey';
         final bird = Bird()..name = 'Louise';
 
-        final orderedSet = QueryableOrderedSet<Animal>(
-          comparator: Comparing.on((e) => e.name),
-        );
+        final orderedSet = _create();
         orderedSet.register<Dog>();
 
         orderedSet.add(dog);
@@ -297,9 +274,7 @@ void main() {
         final dog = Dog()..name = 'Joey';
         final bird = Bird()..name = 'Louise';
 
-        final orderedSet = QueryableOrderedSet<Animal>(
-          comparator: Comparing.on((e) => e.name),
-        );
+        final orderedSet = _create();
         orderedSet.register<Dog>();
 
         orderedSet.add(dog);
@@ -314,4 +289,15 @@ void main() {
       });
     });
   });
+}
+
+QueryableOrderedSet<Animal> _create({
+  bool strictMode = true,
+}) {
+  return OrderedSet.queryable(
+    OrderedSet.comparing<Animal>(
+      Comparing.on((e) => e.name),
+    ),
+    strictMode: strictMode,
+  );
 }

--- a/test/queryable_priority_ordered_set_test.dart
+++ b/test/queryable_priority_ordered_set_test.dart
@@ -1,0 +1,300 @@
+import 'package:ordered_set/ordered_set.dart';
+import 'package:ordered_set/queryable_ordered_set.dart';
+import 'package:test/test.dart';
+
+abstract class Animal {
+  String name = '';
+}
+
+abstract class Mammal extends Animal {}
+
+class Bird extends Animal {}
+
+class Fish extends Animal {}
+
+class Dog extends Mammal {}
+
+class Cat extends Mammal {}
+
+class Cod extends Fish {}
+
+void main() {
+  group('QueryableOrderedSet - Priority', () {
+    group('#add and #query', () {
+      test('registration is mandatory on strict mode', () {
+        final orderedSet = _create();
+
+        expect(
+          () => orderedSet.query<Bird>(),
+          throwsA('Cannot query unregistered query Bird'),
+        );
+      });
+      test('registration is optional with strict mode = false', () {
+        final orderedSet = _create(strictMode: false);
+        final bird = Bird()..name = 'Louise';
+        final cod = Cod()..name = 'Leroy';
+        orderedSet.addAll([bird, cod]);
+
+        orderedSet.register<Cod>();
+        expect(orderedSet.isRegistered<Cod>(), isTrue);
+        expect(orderedSet.isRegistered<Bird>(), isFalse);
+
+        expect(orderedSet.query<Cod>(), unorderedMatches(<Cod>[cod]));
+        expect(orderedSet.isRegistered<Cod>(), isTrue);
+        expect(orderedSet.isRegistered<Bird>(), isFalse);
+
+        expect(orderedSet.query<Bird>(), unorderedMatches(<Bird>[bird]));
+        expect(orderedSet.isRegistered<Cod>(), isTrue);
+        expect(orderedSet.isRegistered<Bird>(), isTrue);
+      });
+      test('#add after #register', () {
+        final dog = Dog()..name = 'Joey';
+        final bird = Bird()..name = 'Louise';
+
+        final orderedSet = _create();
+        orderedSet.register<Animal>();
+        orderedSet.register<Dog>();
+        orderedSet.register<Bird>();
+
+        orderedSet.add(dog);
+        orderedSet.add(bird);
+
+        expect(
+          orderedSet.query<Animal>(),
+          unorderedMatches(<Animal>[dog, bird]),
+        );
+        expect(orderedSet.query<Dog>(), unorderedMatches(<Dog>[dog]));
+        expect(orderedSet.query<Bird>(), unorderedMatches(<Bird>[bird]));
+      });
+      test('#register after #add', () {
+        final dog = Dog()..name = 'Joey';
+        final bird = Bird()..name = 'Louise';
+
+        final orderedSet = _create();
+
+        orderedSet.add(dog);
+        orderedSet.add(bird);
+
+        orderedSet.register<Animal>();
+        orderedSet.register<Dog>();
+        orderedSet.register<Bird>();
+
+        expect(
+          orderedSet.query<Animal>(),
+          unorderedMatches(<Animal>[dog, bird]),
+        );
+        expect(orderedSet.query<Dog>(), unorderedMatches(<Dog>[dog]));
+        expect(orderedSet.query<Bird>(), unorderedMatches(<Bird>[bird]));
+      });
+      test('complex hierarchy', () {
+        final dog = Dog()..name = 'Joey';
+        final fish = Fish()..name = 'Abigail';
+        final cod = Cod()..name = 'Leroy';
+
+        final orderedSet = _create();
+
+        orderedSet.register<Animal>();
+        orderedSet.add(dog);
+
+        orderedSet.register<Mammal>();
+        orderedSet.add(fish);
+
+        orderedSet.register<Dog>();
+        orderedSet.add(cod);
+
+        orderedSet.register<Fish>();
+        orderedSet.register<Cod>();
+
+        expect(
+          orderedSet.query<Animal>(),
+          unorderedMatches(<Animal>[dog, fish, cod]),
+        );
+        expect(orderedSet.query<Mammal>(), unorderedMatches(<Mammal>[dog]));
+        expect(orderedSet.query<Dog>(), unorderedMatches(<Dog>[dog]));
+
+        expect(orderedSet.query<Fish>(), unorderedMatches(<Fish>[fish, cod]));
+        expect(orderedSet.query<Cod>(), unorderedMatches(<Cod>[cod]));
+      });
+      test('#remove', () {
+        final dog = Dog()..name = 'Joey';
+        final bird = Bird()..name = 'Louise';
+
+        final orderedSet = _create();
+        orderedSet.register<Animal>();
+        orderedSet.register<Dog>();
+        orderedSet.register<Bird>();
+
+        orderedSet.add(dog);
+        orderedSet.add(bird);
+
+        orderedSet.remove(dog);
+
+        expect(orderedSet.query<Animal>(), unorderedMatches(<Animal>[bird]));
+        expect(orderedSet.query<Dog>(), unorderedMatches(<Dog>[]));
+        expect(orderedSet.query<Bird>(), unorderedMatches(<Bird>[bird]));
+
+        orderedSet.remove(bird);
+
+        expect(orderedSet.query<Animal>(), unorderedMatches(<Animal>[]));
+        expect(orderedSet.query<Dog>(), unorderedMatches(<Dog>[]));
+        expect(orderedSet.query<Bird>(), unorderedMatches(<Bird>[]));
+      });
+      test('#removeWhere', () {
+        final dog1 = Dog()..name = 'Joey';
+        final dog2 = Dog()..name = 'Thomas';
+        final bird1 = Bird()..name = 'Louise';
+        final bird2 = Bird()..name = 'Sally';
+
+        final orderedSet = _create();
+        orderedSet.register<Animal>();
+        orderedSet.register<Mammal>();
+        orderedSet.register<Dog>();
+        orderedSet.register<Bird>();
+
+        orderedSet.add(dog1);
+        orderedSet.add(dog2);
+        orderedSet.add(bird1);
+        orderedSet.add(bird2);
+
+        expect(
+          orderedSet.query<Animal>(),
+          unorderedMatches(<Animal>[dog1, dog2, bird1, bird2]),
+        );
+        expect(
+          orderedSet.query<Mammal>(),
+          unorderedMatches(<Mammal>[dog1, dog2]),
+        );
+        expect(
+          orderedSet.query<Dog>(),
+          unorderedMatches(<Dog>[dog1, dog2]),
+        );
+        expect(
+          orderedSet.query<Bird>(),
+          unorderedMatches(<Bird>[bird1, bird2]),
+        );
+
+        orderedSet.removeWhere((e) => e.name.endsWith('y')); // Joey and Sally
+
+        expect(
+          orderedSet.query<Animal>(),
+          unorderedMatches(<Animal>[dog2, bird1]),
+        );
+        expect(
+          orderedSet.query<Mammal>(),
+          unorderedMatches(<Mammal>[dog2]),
+        );
+        expect(
+          orderedSet.query<Dog>(),
+          unorderedMatches(<Dog>[dog2]),
+        );
+        expect(
+          orderedSet.query<Bird>(),
+          unorderedMatches(<Bird>[bird1]),
+        );
+
+        orderedSet.removeWhere((e) => e is Dog); // Thomas
+
+        expect(orderedSet.query<Animal>(), unorderedMatches(<Animal>[bird1]));
+        expect(orderedSet.query<Mammal>(), unorderedMatches(<Mammal>[]));
+        expect(orderedSet.query<Dog>(), unorderedMatches(<Dog>[]));
+        expect(orderedSet.query<Bird>(), unorderedMatches(<Bird>[bird1]));
+
+        orderedSet.removeWhere((e) => true); // Louise
+
+        expect(orderedSet.query<Animal>(), unorderedMatches(<Animal>[]));
+        expect(orderedSet.query<Mammal>(), unorderedMatches(<Mammal>[]));
+        expect(orderedSet.query<Dog>(), unorderedMatches(<Dog>[]));
+        expect(orderedSet.query<Bird>(), unorderedMatches(<Bird>[]));
+      });
+      test('#clear', () {
+        final dog1 = Dog()..name = 'Joey';
+        final dog2 = Dog()..name = 'Thomas';
+        final bird1 = Bird()..name = 'Louise';
+        final bird2 = Bird()..name = 'Sally';
+
+        final orderedSet = _create();
+        orderedSet.register<Animal>();
+        orderedSet.register<Mammal>();
+        orderedSet.register<Dog>();
+        orderedSet.register<Bird>();
+
+        orderedSet.add(dog1);
+        orderedSet.add(dog2);
+        orderedSet.add(bird1);
+        orderedSet.add(bird2);
+
+        orderedSet.clear();
+
+        expect(orderedSet.query<Animal>(), unorderedMatches(<Animal>[]));
+        expect(orderedSet.query<Mammal>(), unorderedMatches(<Mammal>[]));
+        expect(orderedSet.query<Dog>(), unorderedMatches(<Dog>[]));
+        expect(orderedSet.query<Bird>(), unorderedMatches(<Bird>[]));
+        expect(orderedSet.toList(), isEmpty);
+      });
+      test('#isRegistered', () {
+        final orderedSet = _create();
+        // No caches should be registered on a clean set
+        expect(orderedSet.isRegistered<Animal>(), isFalse);
+        expect(orderedSet.isRegistered<Mammal>(), isFalse);
+        orderedSet.register<Animal>();
+        // It shouldn't return isTrue for a subclass of a registered cache
+        expect(orderedSet.isRegistered<Mammal>(), isFalse);
+        // The Animal cache should report as registered after it has been
+        // registered
+        expect(orderedSet.isRegistered<Animal>(), isTrue);
+        orderedSet.register<Mammal>();
+        // The Mammal cache should report as registered after it has been
+        // registered
+        expect(orderedSet.isRegistered<Mammal>(), isTrue);
+        // The Animal cache should still be reported as registered after another
+        // cache has been registered
+        expect(orderedSet.isRegistered<Animal>(), isTrue);
+        orderedSet.register<Animal>();
+        // Both caches should still be reported as registered after a cache has
+        // been re-registered (no-op)
+        expect(orderedSet.isRegistered<Animal>(), isTrue);
+        expect(orderedSet.isRegistered<Mammal>(), isTrue);
+        // A call to isRegistered without a type should always be isFalse
+      });
+      test('#query returns Iterable', () {
+        final dog = Dog()..name = 'Joey';
+        final bird = Bird()..name = 'Louise';
+
+        final orderedSet = _create();
+        orderedSet.register<Dog>();
+
+        orderedSet.add(dog);
+        orderedSet.add(bird);
+
+        final dogs = orderedSet.query<Dog>();
+        expect(dogs, isA<Iterable<Dog>>());
+      });
+      test('overridden #whereType works as expected', () {
+        final dog = Dog()..name = 'Joey';
+        final bird = Bird()..name = 'Louise';
+
+        final orderedSet = _create();
+        orderedSet.register<Dog>();
+
+        orderedSet.add(dog);
+        orderedSet.add(bird);
+
+        final dogs = orderedSet.whereType<Dog>();
+        expect(dogs, unorderedMatches(<Dog>[dog]));
+        final birds = orderedSet.whereType<Bird>();
+        expect(birds, unorderedMatches(<Bird>[bird]));
+        final fish = orderedSet.whereType<Fish>();
+        expect(fish, unorderedMatches(<Fish>[]));
+      });
+    });
+  });
+}
+
+QueryableOrderedSet<Animal> _create({
+  bool strictMode = true,
+}) {
+  return OrderedSet.queryable(
+    OrderedSet.mapping<String, Animal>((e) => e.name),
+    strictMode: strictMode,
+  );
+}


### PR DESCRIPTION
This introduces a new type of ordered set that takes a mapper function instead of a comparing function, and thus is able to perform some optimizations much needed in Flame.

In order not to break backwards compatibility too much, the following approach is taken:

* `OrderedSet` becomes an "interface" (in Dart world that is an abstract class)
* We provide two implementations, `ComparingOrderedSet` is the old one, new one is `PriorityOrderedSet`
* You can use static methods on the `OrderedSet` interface to create any sets with helper functions
* `QueryableOrderedSet` takes in the underlying `OrderedSet` so it works with both versions

The new `PriorityOrderedSet` uses a splay tree map instead of splay tree set and thus caches the priorities on the map keys. That means you can safely update priorities or have dynamic priority functions and have consistent behaviour before rebalancing.

This is a much nicer underlying fix for https://github.com/flame-engine/flame/issues/3363 than how we did it on the Flame side.