### PR TITLE
feat!: Introduce new ReadOnlyOrderedSet super-interface 

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,17 +67,15 @@ Note that you could instead just create a `MappingOrderedSet` instead:
   // ...
 ```
 
-## Mapping vs Comparing vs Queryable
+## Mapping vs Comparing
 
-There are three main implementations of the `OrderedSet` interface:
+There are two main implementations of the `OrderedSet` interface:
 
 * `ComparingOrderedSet`: the simplest implementation, takes in a `Comparator` and does not cache
    priorities. It uses Dart's `SplayTreeSet` as a backing implementation.
 * `MappingOrderedSet`: a slightly more advanced implementation that takes in a mapper function
    (maps elements to their priorities) and caches them. It uses Dart's `SplayTreeMap` as a backing
    implementation.
-* `QueryableOrderedSet`: a simple wrapper over either `OrderedSet` that allows for O(1) type
-   queries; if you find yourself doing `.whereType<T>()` a lot, you should consider using this.
 
 In order to create an `OrderedSet`, however, you can just use the static methods on the interface
 itself:
@@ -90,7 +88,19 @@ itself:
   a `MappingOrderedSet` with identity mapping.
 * `OrderedSet.simple<E>()`: if `E extends Comparable<E>`, this is an even simpler way of creating
   a `MappingOrderedSet` with identity mapping.
-* `OrderedSet.queryable<E>(orderedSet)`: wraps the given `OrderedSet` into a `QueryableOrderedSet`.
+
+## Querying
+
+You can [register] a set of queries, i.e., predefined sub-types, whose results, 
+i.e., subsets of this set, are then cached.
+Since the queries have to be type checks, and types are runtime constants, this
+can be vastly optimized.
+
+You can then filter by type by using the [query] method (or using [whereType];
+which is overridden).
+
+Note that you can change [strictMode] to allow for querying for unregistered
+types; if you do so, the registration cost is payed on the first query.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -91,19 +91,16 @@ itself:
 
 ## Querying
 
-You can [register] a set of queries, i.e., predefined sub-types, whose results, 
-i.e., subsets of this set, are then cached.
-Since the queries have to be type checks, and types are runtime constants, this
-can be vastly optimized.
+You can [register] a set of queries, i.e., predefined sub-types, whose results, i.e., subsets of
+this set, are then cached. Since the queries have to be type checks, and types are runtime
+constants, this can be vastly optimized.
 
-You can then filter by type by using the [query] method (or using [whereType];
-which is overridden).
+You can then filter by type by using the [query] method (or using [whereType]; which is overridden).
 
-Note that you can change [strictMode] to allow for querying for unregistered
-types; if you do so, the registration cost is payed on the first query.
+Note that you can change [strictMode] to allow for querying for unregistered types; if you do so,
+the registration cost is payed on the first query.
 
 ## Contributing
 
 All contributions are very welcome! Please feel free to create Issues, help us with PR's or comment
 your suggestions, feature requests, bugs, et cetera. Give us a star if you liked it!
-

--- a/benchmark/main.dart
+++ b/benchmark/main.dart
@@ -8,7 +8,7 @@ import 'types.dart';
 
 void main() {
   OrderedSet<K> comparing<K>(Mapper<K> mapper) {
-    return OrderedSet.comparing<K>(Comparing.on(mapper));
+    return OrderedSet.comparing<K>(compare: Comparing.on(mapper));
   }
 
   OrderedSet<K> priority<K>(Mapper<K> mapper) {

--- a/example/ordered_set_example.dart
+++ b/example/ordered_set_example.dart
@@ -9,7 +9,7 @@ void main() {
   items.add(1);
   print(items.toList()); // [1, 2]
 
-  final a = OrderedSet.comparing<Person>((a, b) => a.age - b.age);
+  final a = OrderedSet.comparing<Person>(compare: (a, b) => a.age - b.age);
   a.add(Person(12, 'Klaus'));
   a.add(Person(1, 'Sunny'));
   a.add(Person(14, 'Violet'));
@@ -25,7 +25,7 @@ void main() {
   // use Comparing for simpler creation:
   // sort by age desc and then name asc
   final b = OrderedSet.comparing<Person>(
-    Comparing.join([(p) => -p.age, (p) => p.name]),
+    compare: Comparing.join([(p) => -p.age, (p) => p.name]),
   );
   b.addAll(a.toList());
   print(b.toList().map((e) => e.name));

--- a/lib/comparing_ordered_set.dart
+++ b/lib/comparing_ordered_set.dart
@@ -16,8 +16,11 @@ class ComparingOrderedSet<E> extends OrderedSet<E>
   // If the default implementation of `Set` changes from `LinkedHashSet` to
   // something else that isn't ordered we'll have to change this to explicitly
   // be `LinkedHashSet` (or some other data structure that preserves order).
-  late SplayTreeSet<Set<E>> _backingSet;
-  late int _length;
+  late final SplayTreeSet<Set<E>> _backingSet = SplayTreeSet<LinkedHashSet<E>>(
+    _outerComparator,
+  );
+  final int Function(E e1, E e2) _comparator;
+  int _length = 0;
 
   bool _validReverseCache = true;
   Iterable<E> _reverseCache = const Iterable.empty();
@@ -45,22 +48,7 @@ class ComparingOrderedSet<E> extends OrderedSet<E>
   ComparingOrderedSet({
     int Function(E e1, E e2)? compare,
     this.strictMode = true,
-  }) {
-    final comparator = compare ?? _defaultCompare<E>();
-    _backingSet = SplayTreeSet<LinkedHashSet<E>>((Set<E> l1, Set<E> l2) {
-      if (l1.isEmpty) {
-        if (l2.isEmpty) {
-          return 0;
-        }
-        return -1;
-      }
-      if (l2.isEmpty) {
-        return 1;
-      }
-      return comparator(l1.first, l2.first);
-    });
-    _length = 0;
-  }
+  }) : _comparator = compare ?? _defaultCompare<E>();
 
   @override
   int get length => _length;
@@ -142,5 +130,18 @@ class ComparingOrderedSet<E> extends OrderedSet<E>
     _backingSet.clear();
     _length = 0;
     onClear();
+  }
+
+  int _outerComparator(Set<E> l1, Set<E> l2) {
+    if (l1.isEmpty) {
+      if (l2.isEmpty) {
+        return 0;
+      }
+      return -1;
+    }
+    if (l2.isEmpty) {
+      return 1;
+    }
+    return _comparator(l1.first, l2.first);
   }
 }

--- a/lib/comparing_ordered_set.dart
+++ b/lib/comparing_ordered_set.dart
@@ -78,8 +78,6 @@ class ComparingOrderedSet<E> extends OrderedSet<E>
     return _reverseCache;
   }
 
-  @pragma('vm:prefer-inline')
-  @pragma('wasm:prefer-inline')
   @override
   bool add(E e) {
     final elementSet = {e};
@@ -109,8 +107,6 @@ class ComparingOrderedSet<E> extends OrderedSet<E>
     addAll(elements);
   }
 
-  @pragma('vm:prefer-inline')
-  @pragma('wasm:prefer-inline')
   @override
   bool remove(E e) {
     var bucket = _backingSet.lookup({e});

--- a/lib/comparing_ordered_set.dart
+++ b/lib/comparing_ordered_set.dart
@@ -78,6 +78,8 @@ class ComparingOrderedSet<E> extends OrderedSet<E>
     return _reverseCache;
   }
 
+  @pragma('vm:prefer-inline')
+  @pragma('wasm:prefer-inline')
   @override
   bool add(E e) {
     final elementSet = {e};
@@ -107,6 +109,8 @@ class ComparingOrderedSet<E> extends OrderedSet<E>
     addAll(elements);
   }
 
+  @pragma('vm:prefer-inline')
+  @pragma('wasm:prefer-inline')
   @override
   bool remove(E e) {
     var bucket = _backingSet.lookup({e});

--- a/lib/comparing_ordered_set.dart
+++ b/lib/comparing_ordered_set.dart
@@ -66,6 +66,8 @@ class ComparingOrderedSet<E> extends OrderedSet<E>
     return _reverseCache;
   }
 
+  @pragma('vm:prefer-inline')
+  @pragma('wasm:prefer-inline')
   @override
   bool add(E e) {
     final elementSet = {e};
@@ -95,6 +97,8 @@ class ComparingOrderedSet<E> extends OrderedSet<E>
     addAll(elements);
   }
 
+  @pragma('vm:prefer-inline')
+  @pragma('wasm:prefer-inline')
   @override
   bool remove(E e) {
     var bucket = _backingSet.lookup({e});

--- a/lib/comparing_ordered_set.dart
+++ b/lib/comparing_ordered_set.dart
@@ -66,8 +66,6 @@ class ComparingOrderedSet<E> extends OrderedSet<E>
     return _reverseCache;
   }
 
-  @pragma('vm:prefer-inline')
-  @pragma('wasm:prefer-inline')
   @override
   bool add(E e) {
     final elementSet = {e};
@@ -97,8 +95,6 @@ class ComparingOrderedSet<E> extends OrderedSet<E>
     addAll(elements);
   }
 
-  @pragma('vm:prefer-inline')
-  @pragma('wasm:prefer-inline')
   @override
   bool remove(E e) {
     var bucket = _backingSet.lookup({e});

--- a/lib/mapping_ordered_set.dart
+++ b/lib/mapping_ordered_set.dart
@@ -46,6 +46,8 @@ class MappingOrderedSet<K extends Comparable<K>, E> extends OrderedSet<E>
     return _reverseCache;
   }
 
+  @pragma('vm:prefer-inline')
+  @pragma('wasm:prefer-inline')
   @override
   bool add(E e) {
     final elementPriority = _mappingFunction(e);
@@ -72,6 +74,8 @@ class MappingOrderedSet<K extends Comparable<K>, E> extends OrderedSet<E>
     addAll(elements);
   }
 
+  @pragma('vm:prefer-inline')
+  @pragma('wasm:prefer-inline')
   @override
   bool remove(E e) {
     K? key = _mappingFunction(e);

--- a/lib/mapping_ordered_set.dart
+++ b/lib/mapping_ordered_set.dart
@@ -44,8 +44,6 @@ class MappingOrderedSet<K extends Comparable<K>, E> extends OrderedSet<E>
     return _reverseCache;
   }
 
-  @pragma('vm:prefer-inline')
-  @pragma('wasm:prefer-inline')
   @override
   bool add(E e) {
     final elementPriority = _mappingFunction(e);
@@ -72,8 +70,6 @@ class MappingOrderedSet<K extends Comparable<K>, E> extends OrderedSet<E>
     addAll(elements);
   }
 
-  @pragma('vm:prefer-inline')
-  @pragma('wasm:prefer-inline')
   @override
   bool remove(E e) {
     K? key = _mappingFunction(e);

--- a/lib/mapping_ordered_set.dart
+++ b/lib/mapping_ordered_set.dart
@@ -3,6 +3,7 @@ import 'dart:collection';
 import 'package:ordered_set/comparing_ordered_set.dart';
 import 'package:ordered_set/ordered_set.dart';
 import 'package:ordered_set/ordered_set_iterator.dart';
+import 'package:ordered_set/queryable_ordered_set_impl.dart';
 
 /// A simple implementation of [OrderedSet] that uses a [SplayTreeMap] as the
 /// backing store.
@@ -10,7 +11,8 @@ import 'package:ordered_set/ordered_set_iterator.dart';
 /// This allows it to keep a cache of elements priorities, so they can be used
 /// changed without rebalancing.
 /// For an alternative implementation, use [ComparingOrderedSet].
-class MappingOrderedSet<K extends Comparable<K>, E> extends OrderedSet<E> {
+class MappingOrderedSet<K extends Comparable<K>, E> extends OrderedSet<E>
+    with QueryableOrderedSetImpl<E> {
   final K Function(E a) _mappingFunction;
   late SplayTreeMap<K, Set<E>> _backingSet;
   late int _length;
@@ -18,7 +20,10 @@ class MappingOrderedSet<K extends Comparable<K>, E> extends OrderedSet<E> {
   bool _validReverseCache = true;
   Iterable<E> _reverseCache = const Iterable.empty();
 
-  MappingOrderedSet(this._mappingFunction) {
+  @override
+  final bool strictMode;
+
+  MappingOrderedSet(this._mappingFunction, {this.strictMode = true}) {
     _backingSet = SplayTreeMap((K k1, K k2) {
       return k1.compareTo(k2);
     });
@@ -49,6 +54,7 @@ class MappingOrderedSet<K extends Comparable<K>, E> extends OrderedSet<E> {
     if (added) {
       _length++;
       _validReverseCache = false;
+      onAdd(e);
     }
     return added;
   }
@@ -94,6 +100,7 @@ class MappingOrderedSet<K extends Comparable<K>, E> extends OrderedSet<E> {
         _backingSet.remove(key);
       }
       _validReverseCache = false;
+      onRemove(e);
     }
     return result;
   }
@@ -103,5 +110,6 @@ class MappingOrderedSet<K extends Comparable<K>, E> extends OrderedSet<E> {
     _validReverseCache = false;
     _backingSet.clear();
     _length = 0;
+    onClear();
   }
 }

--- a/lib/mapping_ordered_set.dart
+++ b/lib/mapping_ordered_set.dart
@@ -46,8 +46,6 @@ class MappingOrderedSet<K extends Comparable<K>, E> extends OrderedSet<E>
     return _reverseCache;
   }
 
-  @pragma('vm:prefer-inline')
-  @pragma('wasm:prefer-inline')
   @override
   bool add(E e) {
     final elementPriority = _mappingFunction(e);
@@ -74,8 +72,6 @@ class MappingOrderedSet<K extends Comparable<K>, E> extends OrderedSet<E>
     addAll(elements);
   }
 
-  @pragma('vm:prefer-inline')
-  @pragma('wasm:prefer-inline')
   @override
   bool remove(E e) {
     K? key = _mappingFunction(e);

--- a/lib/mapping_ordered_set.dart
+++ b/lib/mapping_ordered_set.dart
@@ -14,8 +14,8 @@ import 'package:ordered_set/queryable_ordered_set_impl.dart';
 class MappingOrderedSet<K extends Comparable<K>, E> extends OrderedSet<E>
     with QueryableOrderedSetImpl<E> {
   final K Function(E a) _mappingFunction;
-  late SplayTreeMap<K, Set<E>> _backingSet;
-  late int _length;
+  final SplayTreeMap<K, Set<E>> _backingSet;
+  int _length = 0;
 
   bool _validReverseCache = true;
   Iterable<E> _reverseCache = const Iterable.empty();
@@ -23,12 +23,10 @@ class MappingOrderedSet<K extends Comparable<K>, E> extends OrderedSet<E>
   @override
   final bool strictMode;
 
-  MappingOrderedSet(this._mappingFunction, {this.strictMode = true}) {
-    _backingSet = SplayTreeMap((K k1, K k2) {
-      return k1.compareTo(k2);
-    });
-    _length = 0;
-  }
+  MappingOrderedSet(
+    this._mappingFunction, {
+    this.strictMode = true,
+  }) : _backingSet = SplayTreeMap((K k1, K k2) => k1.compareTo(k2));
 
   @override
   int get length => _length;

--- a/lib/mapping_ordered_set.dart
+++ b/lib/mapping_ordered_set.dart
@@ -44,6 +44,8 @@ class MappingOrderedSet<K extends Comparable<K>, E> extends OrderedSet<E>
     return _reverseCache;
   }
 
+  @pragma('vm:prefer-inline')
+  @pragma('wasm:prefer-inline')
   @override
   bool add(E e) {
     final elementPriority = _mappingFunction(e);
@@ -70,6 +72,8 @@ class MappingOrderedSet<K extends Comparable<K>, E> extends OrderedSet<E>
     addAll(elements);
   }
 
+  @pragma('vm:prefer-inline')
+  @pragma('wasm:prefer-inline')
   @override
   bool remove(E e) {
     K? key = _mappingFunction(e);

--- a/lib/ordered_set.dart
+++ b/lib/ordered_set.dart
@@ -2,7 +2,7 @@ import 'dart:collection';
 
 import 'package:ordered_set/comparing_ordered_set.dart';
 import 'package:ordered_set/mapping_ordered_set.dart';
-import 'package:ordered_set/queryable_ordered_set.dart';
+import 'package:ordered_set/read_only_ordered_set.dart';
 
 /// A simple interface of an ordered set for Dart.
 ///
@@ -10,10 +10,7 @@ import 'package:ordered_set/queryable_ordered_set.dart';
 /// [SplayTreeSet], it allows for several different elements with the same
 /// priority to be added. It also implements [Iterable], so you can iterate it
 /// in O(n).
-abstract class OrderedSet<E> extends IterableMixin<E> {
-  /// The tree's elements in reversed order; should be cached when possible.
-  Iterable<E> reversed();
-
+abstract class OrderedSet<E> extends ReadOnlyOrderedSet<E> {
   /// Adds the element [e] to this, and returns whether the element was
   /// added or not. If the element already exists in the collection, it isn't
   /// added.
@@ -86,18 +83,20 @@ abstract class OrderedSet<E> extends IterableMixin<E> {
   ///
   /// This implementation will not store component priorities, so it is
   /// susceptible to race conditions if priorities are changed while iterating.
-  static ComparingOrderedSet<E> comparing<E>([
+  static ComparingOrderedSet<E> comparing<E>({
     int Function(E a, E b)? compare,
-  ]) {
-    return ComparingOrderedSet<E>(compare);
+    bool strictMode = true,
+  }) {
+    return ComparingOrderedSet<E>(compare: compare, strictMode: strictMode);
   }
 
   /// Creates an instance of [OrderedSet] using the [MappingOrderedSet]
   /// implementation and the provided [mappingFunction].
   static MappingOrderedSet<K, E> mapping<K extends Comparable<K>, E>(
-    K Function(E a) mappingFunction,
-  ) {
-    return MappingOrderedSet(mappingFunction);
+    K Function(E a) mappingFunction, {
+    bool strictMode = true,
+  }) {
+    return MappingOrderedSet(mappingFunction, strictMode: strictMode);
   }
 
   /// Creates an instance of [OrderedSet] for items that are already
@@ -105,24 +104,19 @@ abstract class OrderedSet<E> extends IterableMixin<E> {
   /// Use this for classes that implement [Comparable] of a different class.
   /// Equivalent to `mapping<K, E>((a) => a)`.
   static MappingOrderedSet<K, E>
-      comparable<K extends Comparable<K>, E extends K>() {
-    return mapping<K, E>((a) => a);
+      comparable<K extends Comparable<K>, E extends K>({
+    bool strictMode = true,
+  }) {
+    return mapping<K, E>((a) => a, strictMode: strictMode);
   }
 
   /// Creates an instance of [OrderedSet] for items that are already
   /// [Comparable] of themselves, using the [MappingOrderedSet] implementation.
   /// Use this for classes that implement [Comparable] of themselves.
   /// Equivalent to `mapping<K, K>((a) => a)`.
-  static MappingOrderedSet<E, E> simple<E extends Comparable<E>>() {
-    return comparable<E, E>();
-  }
-
-  /// Creates an instance of [OrderedSet] using the [QueryableOrderedSet]
-  /// by wrapping the provided [backingSet].
-  static QueryableOrderedSet<E> queryable<E>(
-    OrderedSet<E> backingSet, {
+  static MappingOrderedSet<E, E> simple<E extends Comparable<E>>({
     bool strictMode = true,
   }) {
-    return QueryableOrderedSet<E>(backingSet, strictMode: strictMode);
+    return comparable<E, E>(strictMode: strictMode);
   }
 }

--- a/lib/ordered_set.dart
+++ b/lib/ordered_set.dart
@@ -64,12 +64,22 @@ abstract class OrderedSet<E> extends ReadOnlyOrderedSet<E> {
   /// Remove all elements that match the [test] condition; returns the removed
   /// elements.
   Iterable<E> removeWhere(bool Function(E element) test) {
-    return where(test).toList(growable: false)..forEach(remove);
+    final elements = where(test).toList(growable: false);
+    for (final element in elements) {
+      remove(element);
+    }
+    return elements;
   }
 
   /// Remove all [elements] and returns the removed elements.
   Iterable<E> removeAll(Iterable<E> elements) {
-    return elements.where(remove).toList(growable: false);
+    final removed = <E>[];
+    for (final element in elements) {
+      if (remove(element)) {
+        removed.add(element);
+      }
+    }
+    return removed;
   }
 
   /// Removes the element at [index].

--- a/lib/queryable_ordered_set_impl.dart
+++ b/lib/queryable_ordered_set_impl.dart
@@ -22,7 +22,7 @@ mixin QueryableOrderedSetImpl<E> on OrderedSet<E> {
       return;
     }
     _cache[C] = _CacheEntry<C, E>(
-      data: _filter<C>(),
+      _filter<C>(),
     );
   }
 
@@ -62,19 +62,28 @@ mixin QueryableOrderedSetImpl<E> on OrderedSet<E> {
   bool isRegistered<C extends E>() => _cache.containsKey(C);
 
   void onAdd(E t) {
-    _cache.forEach((key, value) {
+    for (final entry in _cache.entries) {
+      final value = entry.value;
       if (value.check(t)) {
         value.data.add(t);
       }
-    });
+    }
   }
 
   void onRemove(E e) {
-    _cache.values.forEach((v) => v.data.remove(e));
+    for (final entry in _cache.entries) {
+      final value = entry.value;
+      if (value.check(e)) {
+        value.data.remove(e);
+      }
+    }
   }
 
   void onClear() {
-    _cache.values.forEach((v) => v.data.clear());
+    for (final entry in _cache.entries) {
+      final value = entry.value;
+      value.data.clear();
+    }
   }
 
   List<C> _filter<C extends E>() => whereType<C>().toList();
@@ -83,7 +92,7 @@ mixin QueryableOrderedSetImpl<E> on OrderedSet<E> {
 class _CacheEntry<C, T> {
   final List<C> data;
 
-  _CacheEntry({required this.data});
+  _CacheEntry(this.data);
 
   bool check(T t) {
     return t is C;

--- a/lib/queryable_ordered_set_impl.dart
+++ b/lib/queryable_ordered_set_impl.dart
@@ -8,16 +8,8 @@ import 'package:ordered_set/ordered_set.dart';
 /// have to be type checks, and types are runtime constants, this can be
 /// vastly optimized.
 ///
-/// If you find yourself doing a lot of:
-///
-/// ```dart
-///   orderedSet.whereType<Foo>()
-/// ```
-///
-/// On your code, and are concerned you are iterating a very long O(n) list to
-/// find a handful of elements, specially if this is done every tick, you
-/// can use this class, that pays a small O(number of registers) cost on [add],
-/// but lets you find (specific) subsets at O(0).
+/// You can then filter by type by using the [query] method (or using
+/// [whereType]; which is overridden).
 ///
 /// Note that you can change [strictMode] to allow for querying for unregistered
 /// types; if you do so, the registration cost is payed on the first query.

--- a/lib/read_only_ordered_set.dart
+++ b/lib/read_only_ordered_set.dart
@@ -1,0 +1,36 @@
+import 'dart:collection';
+
+abstract class ReadOnlyOrderedSet<E> extends IterableMixin<E> {
+  /// The tree's elements in reversed order; should be cached when possible.
+  Iterable<E> reversed();
+
+  /// Controls whether running an unregistered query throws an error or
+  /// performs just-in-time filtering.
+  bool get strictMode;
+
+  /// Whether type [C] is registered as a cache
+  bool isRegistered<C extends E>();
+
+  /// Adds a new cache for a subtype [C] of [E], allowing you to call [query].
+  /// If the cache already exists this operation is a no-op.
+  ///
+  /// If the set is not empty, the current elements will be re-sorted.
+  ///
+  /// It is recommended to [register] all desired types at the beginning of
+  /// your application to avoid recomputing the existing elements upon
+  /// registration.
+  void register<C extends E>();
+
+  /// Allow you to find a subset of this set with all the elements `e` for
+  /// which the condition `e is C` is true. This is equivalent to
+  ///
+  /// ```dart
+  ///   orderedSet.whereType<C>()
+  /// ```
+  ///
+  /// except that it is O(0).
+  ///
+  /// Note: you *must* call [register] for every type [C] you desire to use
+  /// before calling this, or set [strictMode] to false.
+  Iterable<C> query<C extends E>();
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,11 +12,11 @@ topics:
   - ordered-set
 
 environment:
-  sdk: '>=3.4.0 <4.0.0'
+  sdk: '>=3.6.0 <4.0.0'
 
 dev_dependencies:
-  benchmark_harness: ^2.2.2
-  coverage: ^1.8.0
-  dartdoc: ^8.0.9+1
-  flame_lint: ^1.2.0
-  test: ^1.25.7
+  benchmark_harness: ^2.3.1
+  coverage: ^1.13.1
+  dartdoc: ^8.3.3
+  flame_lint: ^1.3.0
+  test: ^1.26.2

--- a/test/comparing_ordered_set_test.dart
+++ b/test/comparing_ordered_set_test.dart
@@ -118,12 +118,14 @@ void main() {
       });
 
       test('with repeated priority elements', () {
-        final a = OrderedSet.comparing<int>((a, b) => (a % 2) - (b % 2));
+        final a = OrderedSet.comparing<int>(
+          compare: (a, b) => (a % 2) - (b % 2),
+        );
         expect(a.addAll([7, 4, 3, 1, 2, 6, 5]), 7);
         expect(a.length, 7);
         expect(a.toList().join(), '4267315');
 
-        final b = OrderedSet.comparing<int>((a, b) => 0);
+        final b = OrderedSet.comparing<int>(compare: (a, b) => 0);
         expect(b.addAll([7, 4, 3, 1, 2, 6, 5]), 7);
         expect(a.length, 7);
         expect(b.toList().join(), '7431265');
@@ -174,7 +176,9 @@ void main() {
       });
 
       test('keeps track of length when removing', () {
-        final a = OrderedSet.comparing<int>((a, b) => 0); // no priority
+        final a = OrderedSet.comparing<int>(
+          compare: (a, b) => 0, // no priority
+        );
         expect(a.addAll([1, 2, 3, 4]), 4);
         expect(a.length, 4);
 
@@ -223,7 +227,7 @@ void main() {
 
       test('test with custom comparator', () {
         final a = OrderedSet.comparing<ComparableObject>(
-          (a, b) => a.name.compareTo(b.name),
+          compare: (a, b) => a.name.compareTo(b.name),
         );
         expect(a.add(ComparableObject(1, 'Sunny')), isTrue);
         expect(a.add(ComparableObject(12, 'Klaus')), isTrue);
@@ -235,7 +239,9 @@ void main() {
       test(
         'test items with repeated comparables, maintain insertion order',
         () {
-          final a = OrderedSet.comparing<int>((a, b) => (a % 2) - (b % 2));
+          final a = OrderedSet.comparing<int>(
+            compare: (a, b) => (a % 2) - (b % 2),
+          );
           for (var i = 0; i < 10; i++) {
             expect(a.add(i), isTrue);
           }
@@ -275,7 +281,7 @@ void main() {
 
       test('with custom comparator, repeated items and removal', () {
         final a = OrderedSet.comparing<ComparableObject>(
-          (a, b) => -a.priority.compareTo(b.priority),
+          compare: (a, b) => -a.priority.compareTo(b.priority),
         );
         final a1 = ComparableObject(2, '1');
         final a2 = ComparableObject(2, '2');
@@ -321,7 +327,7 @@ void main() {
 
       test('removeAll', () {
         final orderedSet = OrderedSet.comparing<ComparableObject>(
-          Comparing.on((e) => e.priority),
+          compare: Comparing.on((e) => e.priority),
         );
 
         final a = ComparableObject(0, 'a');
@@ -361,7 +367,7 @@ void main() {
     group('rebalancing', () {
       test('rebalanceWhere and rebalanceAll', () {
         final orderedSet = OrderedSet.comparing<ComparableObject>(
-          Comparing.on((e) => e.priority),
+          compare: Comparing.on((e) => e.priority),
         );
 
         final a = ComparableObject(0, 'a');
@@ -388,7 +394,7 @@ void main() {
     group('reversed', () {
       test('reversed properly invalidates cache', () {
         final orderedSet = OrderedSet.comparing<ComparableObject>(
-          Comparing.on((e) => e.priority),
+          compare: Comparing.on((e) => e.priority),
         );
 
         final a = ComparableObject(0, 'a');

--- a/test/comparing_test.dart
+++ b/test/comparing_test.dart
@@ -1,5 +1,6 @@
 import 'package:ordered_set/comparing.dart';
 import 'package:ordered_set/comparing_ordered_set.dart';
+import 'package:ordered_set/ordered_set.dart';
 import 'package:test/test.dart';
 
 import 'comparable_object.dart';
@@ -31,7 +32,7 @@ void main() {
       });
       test('using complex object', () {
         final set = ComparingOrderedSet<ComparableObject>(
-          Comparing.on((o) => o.name),
+          compare: Comparing.on((o) => o.name),
         );
         set.add(ComparableObject(0, 'd'));
         set.add(ComparableObject(1, 'b'));
@@ -55,7 +56,7 @@ void main() {
         final c = Comparing.reverse<ComparableObject>(
           Comparing.on((t) => t.name),
         );
-        final set = ComparingOrderedSet(c);
+        final set = OrderedSet.comparing(compare: c);
         set.add(ComparableObject(0, 'd'));
         set.add(ComparableObject(1, 'b'));
         set.add(ComparableObject(2, 'a'));
@@ -70,7 +71,7 @@ void main() {
           (ComparableObject t) => t.priority,
           (ComparableObject t) => t.name,
         ]);
-        final set = ComparingOrderedSet(c);
+        final set = OrderedSet.comparing(compare: c);
         set.add(ComparableObject(1, 'b'));
         set.add(ComparableObject(0, 'b'));
         set.add(ComparableObject(3, 'a'));

--- a/test/queryable_comparable_ordered_set_test.dart
+++ b/test/queryable_comparable_ordered_set_test.dart
@@ -1,6 +1,5 @@
 import 'package:ordered_set/comparing.dart';
 import 'package:ordered_set/ordered_set.dart';
-import 'package:ordered_set/queryable_ordered_set.dart';
 import 'package:test/test.dart';
 
 abstract class Animal {
@@ -291,13 +290,11 @@ void main() {
   });
 }
 
-QueryableOrderedSet<Animal> _create({
+OrderedSet<Animal> _create({
   bool strictMode = true,
 }) {
-  return OrderedSet.queryable(
-    OrderedSet.comparing<Animal>(
-      Comparing.on((e) => e.name),
-    ),
+  return OrderedSet.comparing<Animal>(
+    compare: Comparing.on((e) => e.name),
     strictMode: strictMode,
   );
 }

--- a/test/queryable_priority_ordered_set_test.dart
+++ b/test/queryable_priority_ordered_set_test.dart
@@ -1,5 +1,4 @@
 import 'package:ordered_set/ordered_set.dart';
-import 'package:ordered_set/queryable_ordered_set.dart';
 import 'package:test/test.dart';
 
 abstract class Animal {
@@ -290,11 +289,11 @@ void main() {
   });
 }
 
-QueryableOrderedSet<Animal> _create({
+OrderedSet<Animal> _create({
   bool strictMode = true,
 }) {
-  return OrderedSet.queryable(
-    OrderedSet.mapping<String, Animal>((e) => e.name),
+  return OrderedSet.mapping<String, Animal>(
+    (e) => e.name,
     strictMode: strictMode,
   );
 }


### PR DESCRIPTION
Introduce new `ReadOnlyOrderedSet` super-interface.
Also makes all sets Queryable, removing the prior distinction.